### PR TITLE
Fixed navigation bug in pathfinding algorithm

### DIFF
--- a/src/main/java/nl/tudelft/jpacman/npc/ghost/Navigation.java
+++ b/src/main/java/nl/tudelft/jpacman/npc/ghost/Navigation.java
@@ -1,14 +1,16 @@
 package nl.tudelft.jpacman.npc.ghost;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import java.util.Set;
 
 import nl.tudelft.jpacman.board.Direction;
 import nl.tudelft.jpacman.board.Square;
 import nl.tudelft.jpacman.board.Unit;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Navigation provides utility to nagivate on {@link Square}s.
@@ -90,12 +92,13 @@ public final class Navigation {
 	public static Unit findNearest(Class<? extends Unit> T,
 			Square currentLocation) {
 		long t0 = System.currentTimeMillis();
-		List<Square> targets = new ArrayList<>();
-		List<Square> visited = new ArrayList<>();
-		targets.add(currentLocation);
+		List<Square> toDo = new ArrayList<>();
+		Set<Square> visited = new HashSet<>();
+		
+		toDo.add(currentLocation);
 
-		while (!targets.isEmpty()) {
-			Square square = targets.remove(0);
+		while (!toDo.isEmpty()) {
+			Square square = toDo.remove(0);
 			Unit unit = findUnit(T, square);
 			if (unit != null) {
 				log.debug("Found unit in {}ms.", System.currentTimeMillis()
@@ -105,8 +108,8 @@ public final class Navigation {
 			visited.add(square);
 			for (Direction d : Direction.values()) {
 				Square newTarget = square.getSquareAt(d);
-				if (!visited.contains(newTarget)) {
-					targets.add(newTarget);
+				if (!visited.contains(newTarget) && !toDo.contains(newTarget)) {
+					toDo.add(newTarget);
 				}
 			}
 		}

--- a/src/test/java/nl/tudelft/jpacman/npc/ghost/NavigationTest.java
+++ b/src/test/java/nl/tudelft/jpacman/npc/ghost/NavigationTest.java
@@ -2,9 +2,11 @@ package nl.tudelft.jpacman.npc.ghost;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.mock;
 
+import java.io.IOException;
 import java.util.List;
 
 import nl.tudelft.jpacman.board.Board;
@@ -141,5 +143,13 @@ public class NavigationTest {
 		Square s1 = b.squareAt(0, 0);
 		Unit unit = Navigation.findNearest(Pellet.class, s1);
 		assertNull(unit);
+	}
+	
+	@Test
+	public void testFullSizedLevel() throws IOException {
+		Board b = parser.parseMap(getClass().getResourceAsStream("/board.txt")).getBoard();
+		Square s1 = b.squareAt(1, 1);
+		Unit unit = Navigation.findNearest(Ghost.class, s1);
+		assertNotNull(unit);
 	}
 }


### PR DESCRIPTION
This pull request fixes a bug in the pathfinding algorithm in the `Navigation` class. To find the problem I first benchmarked normal gameplay using jvisualvm. I found that the `findNearest()` method in the `Navigation` class took up 85% of all CPU time whilst playing. To further pin-point the problem I created a test which loads the `board.txt` file, and attempts to locate the closest `Ghost` on the board from the square at `(1, 1)` using the `findNearest()` method. The original `findNearest()` method took 53 seconds to solve this.

I found out that the same `Square` objects were added multiple times to the target list. This meant that every `Square` was visited multiple times, in turn causing more adjacent `Square` objects to be added to the target list again, until all `Square` objects were eventually visited. I've modified the `findNearest()` method to check that an adjacent `Square` object has not yet been visited and is not yet scheduled to be visited. This means that every `Square` is visited exactly one time. Additionally I modified the visited `ArrayList` to a `HashSet` since this has a better lookup time: O(1) vs. O(n).

Where the original solution took 53 seconds to solve the new test, this solution takes 15-20 milliseconds.
