### PR TITLE
Switching to java 8.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,6 @@ language: java
 before_install:
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"
+jdk:
+  - oraclejdk8
 script: "mvn clean test"

--- a/pom.xml
+++ b/pom.xml
@@ -55,8 +55,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.2</version>
 				<configuration>
-					<target>1.7</target>
-					<source>1.7</source>
+					<target>1.8</target>
+					<source>1.8</source>
 				</configuration>
 			</plugin>
 


### PR DESCRIPTION
Getting maven ready for java 8.

In Travis, Java7 is default at the moment, which is why java 8 has to be explicitly configured.