### PR TITLE
Support Checkstyle SuppressWarnings annotations

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -11,6 +11,7 @@
 <module name="Checker">
   <property name="severity" value="warning"/>
   <module name="TreeWalker">
+    <module name="SuppressWarningsHolder" />
     <property name="tabWidth" value="4"/>
     <module name="FileContentsHolder"/>
     <module name="JavadocMethod">
@@ -120,4 +121,5 @@
   </module>
   <module name="SuppressionCommentFilter"/>
   <module name="SuppressWithNearbyCommentFilter"/>
+  <module name="SuppressWarningsFilter" />
 </module>

--- a/src/test/java/nl/tudelft/jpacman/LauncherSmokeTest.java
+++ b/src/test/java/nl/tudelft/jpacman/LauncherSmokeTest.java
@@ -26,6 +26,7 @@ import org.junit.Test;
  *
  * @author Arie van Deursen, March 2014.
  */
+@SuppressWarnings("magicnumber")
 public class LauncherSmokeTest {
 	
 	private Launcher launcher;

--- a/src/test/java/nl/tudelft/jpacman/LauncherSmokeTest.java
+++ b/src/test/java/nl/tudelft/jpacman/LauncherSmokeTest.java
@@ -49,10 +49,13 @@ public class LauncherSmokeTest {
 	}
 
     /**
-     * Launch the game, and imitate what would happen
-     * in a typical game.
+     * Launch the game, and imitate what would happen in a typical game.
+     * The test is only a smoke test, and not a focused small test.
+     * Therefore it is OK that the method is a bit too long.
+     * 
      * @throws InterruptedException Since we're sleeping in this test.
      */
+    @SuppressWarnings("methodlength")
     @Test
     public void smokeTest() throws InterruptedException {
         Game game = launcher.getGame();        

--- a/src/test/java/nl/tudelft/jpacman/npc/ghost/NavigationTest.java
+++ b/src/test/java/nl/tudelft/jpacman/npc/ghost/NavigationTest.java
@@ -30,6 +30,7 @@ import com.google.common.collect.Lists;
  * @author Jeroen Roosen 
  * 
  */
+@SuppressWarnings("magicnumber")
 public class NavigationTest {
 
 	/**

--- a/src/test/java/nl/tudelft/jpacman/sprite/SpriteTest.java
+++ b/src/test/java/nl/tudelft/jpacman/sprite/SpriteTest.java
@@ -13,6 +13,7 @@ import org.junit.Test;
  * 
  * @author Jeroen Roosen 
  */
+@SuppressWarnings("magicnumber")
 public class SpriteTest {
 
     private Sprite sprite;


### PR DESCRIPTION
Enable the use of annotations to suppress specific checkstyle warnings.

Disable certain magic number warnings in test cases,
and disable the long method warning for the smoke test.