### PR TITLE
Added symmetry to PlayerCollisions.

### DIFF
--- a/src/main/java/nl/tudelft/jpacman/level/PlayerCollisions.java
+++ b/src/main/java/nl/tudelft/jpacman/level/PlayerCollisions.java
@@ -25,6 +25,9 @@ public class PlayerCollisions implements CollisionMap {
 		else if (mover instanceof Ghost) {
 			ghostColliding((Ghost) mover, collidedOn);
 		}
+		else if (mover instanceof Pellet) {
+			pelletColliding((Pellet) mover, collidedOn);
+		}
 	}
 	
 	private void playerColliding(Player player, Unit collidedOn) {
@@ -41,6 +44,12 @@ public class PlayerCollisions implements CollisionMap {
 		if (collidedOn instanceof Player) {
 			playerVersusGhost((Player) collidedOn, ghost);
 		}
+	}
+	
+	private void pelletColliding(Pellet pellet, Unit collidedOn) {
+		if (collidedOn instanceof Player) {
+			playerVersusPellet((Player) collidedOn, pellet);
+		}		
 	}
 	
 	


### PR DESCRIPTION
Without this symmetry, with exercise 13, it becomes impossible to 
make one test suite for both PlayerCollisions and DefaultPlayerInteractionMap.
If a Pellet would collide with the Player, the Pellet should also be
removed and points should be added. InteractionMap is symmetric
and was able to handle this, but PlayerCollisions was not.