### PR TITLE
Enable pmd, checkstyle, and findbugs

### DIFF
--- a/pmd-rules.xml
+++ b/pmd-rules.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0"?>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         name="Custom ruleset"
+         xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
+         xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 http://pmd.sourceforge.net/ruleset_2_0_0.xsd">
+
+    <description>
+        Custom rules for checking JUnit test quality.
+    </description>
+
+    <rule ref="rulesets/java/basic.xml"/>
+    <rule ref="rulesets/java/unusedcode.xml"/>
+    <rule ref="rulesets/java/imports.xml"/>
+    <rule ref="rulesets/java/strings.xml"/>
+    <rule ref="rulesets/java/codesize.xml"/>
+    <rule ref="rulesets/java/braces.xml"/>
+    <rule ref="rulesets/java/clone.xml"/>
+    <rule ref="rulesets/java/empty.xml"/>
+    <rule ref="rulesets/java/junit.xml">
+        <exclude name="JUnitAssertionsShouldIncludeMessage"/>
+	<exclude name="JUnitTestContainsTooManyAsserts" />
+    </rule>
+    <rule ref="rulesets/java/junit.xml/JUnitTestContainsTooManyAsserts">
+        <properties>
+            <property name="maximumAsserts" value="5" />
+        </properties>
+    </rule>
+</ruleset>

--- a/pmd-rules.xml
+++ b/pmd-rules.xml
@@ -1,28 +1,36 @@
 <?xml version="1.0"?>
 <ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         name="Custom ruleset"
-         xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
-         xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 http://pmd.sourceforge.net/ruleset_2_0_0.xsd">
+	name="Custom ruleset" xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
+	xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 http://pmd.sourceforge.net/ruleset_2_0_0.xsd">
 
-    <description>
+	<description>
         Custom rules for checking JUnit test quality.
     </description>
 
-    <rule ref="rulesets/java/basic.xml"/>
-    <rule ref="rulesets/java/unusedcode.xml"/>
-    <rule ref="rulesets/java/imports.xml"/>
-    <rule ref="rulesets/java/strings.xml"/>
-    <rule ref="rulesets/java/codesize.xml"/>
-    <rule ref="rulesets/java/braces.xml"/>
-    <rule ref="rulesets/java/clone.xml"/>
-    <rule ref="rulesets/java/empty.xml"/>
-    <rule ref="rulesets/java/junit.xml">
-        <exclude name="JUnitAssertionsShouldIncludeMessage"/>
-	<exclude name="JUnitTestContainsTooManyAsserts" />
-    </rule>
-    <rule ref="rulesets/java/junit.xml/JUnitTestContainsTooManyAsserts">
-        <properties>
-            <property name="maximumAsserts" value="5" />
-        </properties>
-    </rule>
+	<rule ref="rulesets/java/basic.xml" />
+	<rule ref="rulesets/java/unusedcode.xml" />
+	<rule ref="rulesets/java/imports.xml" />
+	<rule ref="rulesets/java/imports.xml/TooManyStaticImports">
+		<properties>
+			<property name="maximumStaticImports" value="8" />
+		</properties>
+	</rule>
+	<rule ref="rulesets/java/strings.xml" />
+	<rule ref="rulesets/java/strings.xml/AvoidDuplicateLiterals">
+		<properties>
+			<property name="skipAnnotations" value="true" />
+		</properties>
+	</rule>
+	<rule ref="rulesets/java/codesize.xml" />
+	<rule ref="rulesets/java/braces.xml" />
+	<rule ref="rulesets/java/clone.xml" />
+	<rule ref="rulesets/java/empty.xml" />
+	<rule ref="rulesets/java/junit.xml">
+		<exclude name="JUnitAssertionsShouldIncludeMessage" />
+	</rule>
+	<rule ref="rulesets/java/junit.xml/JUnitTestContainsTooManyAsserts">
+		<properties>
+			<property name="maximumAsserts" value="4" />
+		</properties>
+	</rule>
 </ruleset>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
 	<groupId>nl.tudelft.jpacman</groupId>
 	<artifactId>jpacman-framework</artifactId>
-	<version>6.2.0</version>
+	<version>6.3.0-SNAPSHOT</version>
 	<url>https://github.com/serg-delft/jpacman-framework</url>
 	<description>
         Pacman-inspired game, for teaching testing purposes.

--- a/pom.xml
+++ b/pom.xml
@@ -11,21 +11,21 @@
 	<groupId>nl.tudelft.jpacman</groupId>
 	<artifactId>jpacman-framework</artifactId>
 	<version>6.2.0</version>
-    <url>https://github.com/serg-delft/jpacman-framework</url>
-    <description>
+	<url>https://github.com/serg-delft/jpacman-framework</url>
+	<description>
         Pacman-inspired game, for teaching testing purposes.
     </description>
-    <organization>
-        <url>http://www.tudelft.nl</url>
-        <name>Delft University of Technology</name>
-    </organization>
-    <licenses>
-        <license>
-            <name>Apache License, Version 2.0</name>
-            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
-            <distribution>repo</distribution>
-        </license>
-    </licenses>
+	<organization>
+		<url>http://www.tudelft.nl</url>
+		<name>Delft University of Technology</name>
+	</organization>
+	<licenses>
+		<license>
+			<name>Apache License, Version 2.0</name>
+			<url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+			<distribution>repo</distribution>
+		</license>
+	</licenses>
 
 	<distributionManagement>
 		<repository>
@@ -43,6 +43,9 @@
 		<maven.compiler.target>1.8</maven.compiler.target>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+		<checkstyle.plugin.version>2.15</checkstyle.plugin.version>
+		<pmd.plugin.version>3.4</pmd.plugin.version>
+		<findbugs.version>3.0.0</findbugs.version>
 	</properties>
 
 	<dependencies>
@@ -82,7 +85,7 @@
 					</execution>
 				</executions>
 			</plugin>
-			
+
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-jar-plugin</artifactId>
@@ -105,70 +108,131 @@
 					</execution>
 				</executions>
 			</plugin>
- 		</plugins>
+
+			<!-- The checkstyle, findbugs and PMD plugins have configurations, for 
+				the checkstyle:checkstyle and pmd:pmd to work properly, the plugins should 
+				also be specified under the build section. See: https://github.com/sevntu-checkstyle/checkstyle-samples/blob/master/maven-project/pom.xml -->
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-checkstyle-plugin</artifactId>
+				<version>${checkstyle.plugin.version}</version>
+				<configuration>
+					<configLocation>${basedir}/checkstyle.xml</configLocation>
+					<includeTestSourceDirectory>true</includeTestSourceDirectory>
+				</configuration>
+			</plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-pmd-plugin</artifactId>
+				<version>${pmd.plugin.version}</version>
+				<configuration>
+					<skipEmptyReport>false</skipEmptyReport>
+					<includeTests>true</includeTests>
+					<rulesets>
+						<ruleset>pmd-rules.xml</ruleset>
+					</rulesets>
+				</configuration>
+			</plugin>
+
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>findbugs-maven-plugin</artifactId>
+				<version>${findbugs.version}</version>
+				<configuration>
+					<xmlOutput>true</xmlOutput>
+					<includeTests>true</includeTests>
+				</configuration>
+			</plugin>
+		</plugins>
 	</build>
 
-    <reporting>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-project-info-reports-plugin</artifactId>
-                <version>2.8</version>
-            </plugin>
+	<reporting>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-project-info-reports-plugin</artifactId>
+				<version>2.8</version>
+			</plugin>
 
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.10.1</version>
-                <configuration>
-                    <failOnError>false</failOnError>
-                </configuration>
-                <reportSets>
-                    <reportSet>
-                        <id>default</id>
-                        <reports>
-                            <report>javadoc</report>
-                        </reports>
-                    </reportSet>
-                </reportSets>
-            </plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-javadoc-plugin</artifactId>
+				<version>2.10.1</version>
+				<configuration>
+					<failOnError>false</failOnError>
+				</configuration>
+				<reportSets>
+					<reportSet>
+						<id>default</id>
+						<reports>
+							<report>javadoc</report>
+						</reports>
+					</reportSet>
+				</reportSets>
+			</plugin>
 
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jxr-plugin</artifactId>
-                <configuration>
-                    <linkJavadoc>true</linkJavadoc>
-                </configuration>
-                <version>2.5</version>
-            </plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-jxr-plugin</artifactId>
+				<configuration>
+					<linkJavadoc>true</linkJavadoc>
+				</configuration>
+				<version>2.5</version>
+			</plugin>
 
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>2.15</version>
-                <configuration>
-                    <configLocation>${basedir}/checkstyle.xml</configLocation>
-                    <includeTestSourceDirectory> true </includeTestSourceDirectory>
-                </configuration>
-            </plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-checkstyle-plugin</artifactId>
+				<version>${checkstyle.plugin.version}</version>
+				<configuration>
+					<configLocation>${basedir}/checkstyle.xml</configLocation>
+					<includeTestSourceDirectory>true</includeTestSourceDirectory>
+				</configuration>
+			</plugin>
 
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>findbugs-maven-plugin</artifactId>
-                <version>3.0.0</version>
-            </plugin>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>findbugs-maven-plugin</artifactId>
+				<version>3.0.0</version>
+			</plugin>
 
-            <plugin> <!-- JUnit report -->
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-report-plugin</artifactId>
-                <version>2.18.1</version>
-            </plugin>
+			<plugin> <!-- JUnit report -->
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-report-plugin</artifactId>
+				<version>2.18.1</version>
+			</plugin>
 
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>cobertura-maven-plugin</artifactId>
-                <version>2.7</version>
-            </plugin>
-        </plugins>
-    </reporting>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>cobertura-maven-plugin</artifactId>
+				<version>2.7</version>
+			</plugin>
+
+			<!-- PMD configuration for JUnit tests -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-pmd-plugin</artifactId>
+				<version>${pmd.plugin.version}</version>
+				<configuration>
+					<skipEmptyReport>false</skipEmptyReport>
+					<includeTests>true</includeTests>
+					<rulesets>
+						<ruleset>pmd-rules.xml</ruleset>
+					</rulesets>
+				</configuration>
+			</plugin>
+
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>findbugs-maven-plugin</artifactId>
+				<version>${findbugs.version}</version>
+				<configuration>
+					<xmlOutput>true</xmlOutput>
+					<includeTests>true</includeTests>
+				</configuration>
+			</plugin>
+		</plugins>
+	</reporting>
 </project>

--- a/src/test/java/nl/tudelft/jpacman/board/BoardFactoryTest.java
+++ b/src/test/java/nl/tudelft/jpacman/board/BoardFactoryTest.java
@@ -23,7 +23,7 @@ public class BoardFactoryTest {
 	 * Resets the factory under test.
 	 */
 	@Before
-	public void setup() {
+	public void setUp() {
 		PacManSprites sprites = mock(PacManSprites.class);
 		factory = new BoardFactory(sprites);
 	}

--- a/src/test/java/nl/tudelft/jpacman/board/BoardTest.java
+++ b/src/test/java/nl/tudelft/jpacman/board/BoardTest.java
@@ -29,7 +29,7 @@ public class BoardTest {
 	 * Setup a board that can be used for testing.
 	 */
 	@Before
-	public void setup() {
+	public void setUp() {
 		Square[][] grid = new Square[maxWidth][maxHeight];
 		grid[0][0] = x0y0;
 		grid[0][1] = x0y1;

--- a/src/test/java/nl/tudelft/jpacman/board/OccupantTest.java
+++ b/src/test/java/nl/tudelft/jpacman/board/OccupantTest.java
@@ -24,7 +24,7 @@ public class OccupantTest {
 	 * Resets the unit under test.
 	 */
 	@Before
-	public void setup() {
+	public void setUp() {
 		unit = new BasicUnit();
 	}
 

--- a/src/test/java/nl/tudelft/jpacman/board/SquareTest.java
+++ b/src/test/java/nl/tudelft/jpacman/board/SquareTest.java
@@ -24,7 +24,7 @@ public class SquareTest {
 	 * Resets the square under test.
 	 */
 	@Before
-	public void setup() {
+	public void setUp() {
 		square = new BasicSquare();
 	}
 

--- a/src/test/java/nl/tudelft/jpacman/level/LevelTest.java
+++ b/src/test/java/nl/tudelft/jpacman/level/LevelTest.java
@@ -57,7 +57,7 @@ public class LevelTest {
 	 * square.
 	 */
 	@Before
-	public void setup() {
+	public void setUp() {
 		final long defaultInterval = 100L;
 		level = new Level(board, Lists.newArrayList(ghost), Lists.newArrayList(
 				square1, square2), collisions);

--- a/src/test/java/nl/tudelft/jpacman/level/LevelTest.java
+++ b/src/test/java/nl/tudelft/jpacman/level/LevelTest.java
@@ -105,6 +105,7 @@ public class LevelTest {
 	 * square.
 	 */
 	@Test
+	@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
 	public void registerPlayer() {
 		Player p = mock(Player.class);
 		level.registerPlayer(p);
@@ -115,6 +116,7 @@ public class LevelTest {
 	 * Verifies registering a player twice does not do anything.
 	 */
 	@Test
+	@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
 	public void registerPlayerTwice() {
 		Player p = mock(Player.class);
 		level.registerPlayer(p);
@@ -127,6 +129,7 @@ public class LevelTest {
 	 * starting square.
 	 */
 	@Test
+	@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
 	public void registerSecondPlayer() {
 		Player p1 = mock(Player.class);
 		Player p2 = mock(Player.class);
@@ -140,6 +143,7 @@ public class LevelTest {
 	 * starting square.
 	 */
 	@Test
+	@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
 	public void registerThirdPlayer() {
 		Player p1 = mock(Player.class);
 		Player p2 = mock(Player.class);

--- a/src/test/java/nl/tudelft/jpacman/npc/ghost/NavigationTest.java
+++ b/src/test/java/nl/tudelft/jpacman/npc/ghost/NavigationTest.java
@@ -30,7 +30,7 @@ import com.google.common.collect.Lists;
  * @author Jeroen Roosen 
  * 
  */
-@SuppressWarnings("magicnumber")
+@SuppressWarnings({"magicnumber", "PMD.AvoidDuplicateLiterals"})
 public class NavigationTest {
 
 	/**

--- a/src/test/java/nl/tudelft/jpacman/npc/ghost/NavigationTest.java
+++ b/src/test/java/nl/tudelft/jpacman/npc/ghost/NavigationTest.java
@@ -42,7 +42,7 @@ public class NavigationTest {
 	 * Set up the map parser.
 	 */
 	@Before
-	public void setup() {
+	public void setUp() {
 		PacManSprites sprites = new PacManSprites();
 		parser = new MapParser(new LevelFactory(sprites, new GhostFactory(
 				sprites)), new BoardFactory(sprites));


### PR DESCRIPTION
Configured maven so that findbugs, checkstyle, and pmd can be invoked separately and as part of the site target.

Cleaned up some of the code given the resulting warnings.

Bumped version to 6.3.0-SNAPSHOT