### PR TITLE
Suppress non-useful PMD warnings

### DIFF
--- a/src/main/java/nl/tudelft/jpacman/Launcher.java
+++ b/src/main/java/nl/tudelft/jpacman/Launcher.java
@@ -25,6 +25,7 @@ import nl.tudelft.jpacman.ui.PacManUiBuilder;
  * 
  * @author Jeroen Roosen 
  */
+@SuppressWarnings("PMD.TooManyMethods")
 public class Launcher {
 
 	private static final PacManSprites SPRITE_STORE = new PacManSprites();

--- a/src/main/java/nl/tudelft/jpacman/level/Level.java
+++ b/src/main/java/nl/tudelft/jpacman/level/Level.java
@@ -23,6 +23,7 @@ import nl.tudelft.jpacman.npc.NPC;
  * 
  * @author Jeroen Roosen 
  */
+@SuppressWarnings("PMD.TooManyMethods")
 public class Level {
 
 	/**

--- a/src/test/java/nl/tudelft/jpacman/LauncherSmokeTest.java
+++ b/src/test/java/nl/tudelft/jpacman/LauncherSmokeTest.java
@@ -55,7 +55,7 @@ public class LauncherSmokeTest {
      * 
      * @throws InterruptedException Since we're sleeping in this test.
      */
-    @SuppressWarnings("methodlength")
+    @SuppressWarnings({"methodlength", "PMD.JUnitTestContainsTooManyAsserts"})
     @Test
     public void smokeTest() throws InterruptedException {
         Game game = launcher.getGame();        

--- a/src/test/java/nl/tudelft/jpacman/level/LevelTest.java
+++ b/src/test/java/nl/tudelft/jpacman/level/LevelTest.java
@@ -20,6 +20,8 @@ import com.google.common.collect.Lists;
  * 
  * @author Jeroen Roosen 
  */
+// The four suppresswarnings ignore the same rule, which results in 4 same string literals
+@SuppressWarnings({"PMD.AvoidDuplicateLiterals", "PMD.TooManyStaticImports"})
 public class LevelTest {
 
 	/**

--- a/src/test/java/nl/tudelft/jpacman/npc/ghost/NavigationTest.java
+++ b/src/test/java/nl/tudelft/jpacman/npc/ghost/NavigationTest.java
@@ -30,7 +30,7 @@ import com.google.common.collect.Lists;
  * @author Jeroen Roosen 
  * 
  */
-@SuppressWarnings({"magicnumber", "PMD.AvoidDuplicateLiterals"})
+@SuppressWarnings({"magicnumber", "PMD.AvoidDuplicateLiterals", "PMD.TooManyStaticImports"})
 public class NavigationTest {
 
 	/**


### PR DESCRIPTION
Suppresses several PMD warnings that are intentional due to for example the usage of Mockito.