### PR TITLE
Fix findbugs warnings

### DIFF
--- a/src/main/java/nl/tudelft/jpacman/ui/ScorePanel.java
+++ b/src/main/java/nl/tudelft/jpacman/ui/ScorePanel.java
@@ -32,7 +32,7 @@ public class ScorePanel extends JPanel {
 	/**
 	 * The default way in which the score is shown.
 	 */
-	public static final ScoreFormatter DEFAULT_SCORE_FORMATTER = 
+	public static final ScoreFormatter DEFAULT_SCORE_FORMATTER =
 			// this lambda breaks cobertura 2.7 ...
 			// player) -> String.format("Score: %3d", player.getScore());
 			new ScoreFormatter() {
@@ -40,7 +40,7 @@ public class ScorePanel extends JPanel {
 					return String.format("Score: %3d", p.getScore());
 				}
 			};
-	
+
 	/**
 	 * The way to format the score information.
 	 */
@@ -73,13 +73,14 @@ public class ScorePanel extends JPanel {
 	 * Refreshes the scores of the players.
 	 */
 	protected void refresh() {
-		for (Player p : scoreLabels.keySet()) {
+		for (Map.Entry<Player, JLabel> entry : scoreLabels.entrySet()) {
+			Player p = entry.getKey();
 			String score = "";
 			if (!p.isAlive()) {
 				score = "You died. ";
 			}
 			score += scoreFormatter.format(p);
-			scoreLabels.get(p).setText(score);
+			entry.getValue().setText(score);
 		}
 	}
 	

--- a/src/test/java/nl/tudelft/jpacman/npc/ghost/NavigationTest.java
+++ b/src/test/java/nl/tudelft/jpacman/npc/ghost/NavigationTest.java
@@ -7,6 +7,7 @@ import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.mock;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.List;
 
 import nl.tudelft.jpacman.board.Board;
@@ -154,9 +155,11 @@ public class NavigationTest {
 	 */
 	@Test
 	public void testFullSizedLevel() throws IOException {
-		Board b = parser.parseMap(getClass().getResourceAsStream("/board.txt")).getBoard();
-		Square s1 = b.squareAt(1, 1);
-		Unit unit = Navigation.findNearest(Ghost.class, s1);
-		assertNotNull(unit);
+		try (InputStream i = getClass().getResourceAsStream("/board.txt")) {
+			Board b = parser.parseMap(i).getBoard();
+			Square s1 = b.squareAt(1, 1);
+			Unit unit = Navigation.findNearest(Ghost.class, s1);
+			assertNotNull(unit);
+		}
 	}
 }


### PR DESCRIPTION
The first fix was iterating over the EntrySet instead of the KeySet, as we also required the value inside the loop. The second fix was auto-closing of the InputStream in the event of not finding the resource.