### PR TITLE
Fix duplication in ghost interval calculation

### DIFF
--- a/src/main/java/nl/tudelft/jpacman/level/LevelFactory.java
+++ b/src/main/java/nl/tudelft/jpacman/level/LevelFactory.java
@@ -130,12 +130,7 @@ public class LevelFactory {
 		 *            The sprite for the ghost.
 		 */
 		RandomGhost(Map<Direction, Sprite> ghostSprite) {
-			super(ghostSprite);
-		}
-
-		@Override
-		public long getInterval() {
-			return DELAY;
+			super(ghostSprite, (int) DELAY, 0);
 		}
 
 		@Override

--- a/src/main/java/nl/tudelft/jpacman/npc/ghost/Blinky.java
+++ b/src/main/java/nl/tudelft/jpacman/npc/ghost/Blinky.java
@@ -2,7 +2,6 @@ package nl.tudelft.jpacman.npc.ghost;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Random;
 
 import nl.tudelft.jpacman.board.Direction;
 import nl.tudelft.jpacman.board.Square;
@@ -57,15 +56,10 @@ public class Blinky extends Ghost {
 	 * @param spriteMap
 	 *            The sprites for this ghost.
 	 */
+	// TODO Blinky should speed up when there are a few pellets left, but he
+	// has no way to find out how many there are.
 	public Blinky(Map<Direction, Sprite> spriteMap) {
-		super(spriteMap);
-	}
-
-	@Override
-	public long getInterval() {
-		// TODO Blinky should speed up when there are a few pellets left, but he
-		// has no way to find out how many there are.
-		return MOVE_INTERVAL + new Random().nextInt(INTERVAL_VARIATION);
+		super(spriteMap, MOVE_INTERVAL, INTERVAL_VARIATION);
 	}
 
 	/**

--- a/src/main/java/nl/tudelft/jpacman/npc/ghost/Clyde.java
+++ b/src/main/java/nl/tudelft/jpacman/npc/ghost/Clyde.java
@@ -3,7 +3,6 @@ package nl.tudelft.jpacman.npc.ghost;
 import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Random;
 
 import nl.tudelft.jpacman.board.Direction;
 import nl.tudelft.jpacman.board.Square;
@@ -76,12 +75,7 @@ public class Clyde extends Ghost {
 	 *            The sprites for this ghost.
 	 */
 	public Clyde(Map<Direction, Sprite> spriteMap) {
-		super(spriteMap);
-	}
-
-	@Override
-	public long getInterval() {
-		return MOVE_INTERVAL + new Random().nextInt(INTERVAL_VARIATION);
+		super(spriteMap, MOVE_INTERVAL, INTERVAL_VARIATION);
 	}
 
 	/**

--- a/src/main/java/nl/tudelft/jpacman/npc/ghost/Ghost.java
+++ b/src/main/java/nl/tudelft/jpacman/npc/ghost/Ghost.java
@@ -23,18 +23,39 @@ public abstract class Ghost extends NPC {
 	private final Map<Direction, Sprite> sprites;
 
 	/**
+	 * The base move interval of the ghost.
+	 */
+	private final int moveInterval;
+
+	/**
+	 * The random variation added to the {@link #moveInterval}.
+	 */
+	private final int intervalVariation;
+
+	/**
 	 * Creates a new ghost.
-	 * 
+	 *
 	 * @param spriteMap
 	 *            The sprites for every direction.
+	 * @param moveInterval
+	 * 			  The base interval of movement.
+	 * @param intervalVariation
+	 * 			  The variation of the interval.
 	 */
-	protected Ghost(Map<Direction, Sprite> spriteMap) {
+	protected Ghost(Map<Direction, Sprite> spriteMap, int moveInterval, int intervalVariation) {
 		this.sprites = spriteMap;
+		this.intervalVariation = intervalVariation;
+		this.moveInterval = moveInterval;
 	}
 
 	@Override
 	public Sprite getSprite() {
 		return sprites.get(getDirection());
+	}
+
+	@Override
+	public long getInterval() {
+		return this.moveInterval + new Random().nextInt(this.intervalVariation);
 	}
 
 	/**

--- a/src/main/java/nl/tudelft/jpacman/npc/ghost/Inky.java
+++ b/src/main/java/nl/tudelft/jpacman/npc/ghost/Inky.java
@@ -2,7 +2,6 @@ package nl.tudelft.jpacman.npc.ghost;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Random;
 
 import nl.tudelft.jpacman.board.Direction;
 import nl.tudelft.jpacman.board.Square;
@@ -63,12 +62,7 @@ public class Inky extends Ghost {
 	 *            The sprites for this ghost.
 	 */
 	public Inky(Map<Direction, Sprite> spriteMap) {
-		super(spriteMap);
-	}
-
-	@Override
-	public long getInterval() {
-		return MOVE_INTERVAL + new Random().nextInt(INTERVAL_VARIATION);
+		super(spriteMap, MOVE_INTERVAL, INTERVAL_VARIATION);
 	}
 
 	/**

--- a/src/main/java/nl/tudelft/jpacman/npc/ghost/Pinky.java
+++ b/src/main/java/nl/tudelft/jpacman/npc/ghost/Pinky.java
@@ -2,7 +2,6 @@ package nl.tudelft.jpacman.npc.ghost;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Random;
 
 import nl.tudelft.jpacman.board.Direction;
 import nl.tudelft.jpacman.board.Square;
@@ -69,12 +68,7 @@ public class Pinky extends Ghost {
 	 *            The sprites for this ghost.
 	 */
 	public Pinky(Map<Direction, Sprite> spriteMap) {
-		super(spriteMap);
-	}
-
-	@Override
-	public long getInterval() {
-		return MOVE_INTERVAL + new Random().nextInt(INTERVAL_VARIATION);
+		super(spriteMap, MOVE_INTERVAL, INTERVAL_VARIATION);
 	}
 
 	/**


### PR DESCRIPTION
CPD reported duplication in the Ghosts. All Ghosts were using the same interval calculation, this method was therefore moved into Ghost instead.