### PR TITLE
Bump cucumber to fix issue with file path containing spaces

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
 		<junit.version>4.12</junit.version>
 		<mockito.version>2.0.47-beta</mockito.version>
 		<hamcrest.version>1.3</hamcrest.version>
-		<cucumber.version>1.2.2</cucumber.version>
+		<cucumber.version>1.2.4</cucumber.version>
 
 
 		<surefire.plugin.version>2.19.1</surefire.plugin.version>


### PR DESCRIPTION
If the file path included a space, cucumber threw a FileNotFoundException. This was fixed in Cucumber 1.2.4. (ref: https://github.com/cucumber/cucumber-jvm/issues/866)