### PR TITLE
Fix Javadoc of ParameterizedAssignment

### DIFF
--- a/src/main/java/nl/tudelft/jpacman/annotations/ParameterizedAssignment.java
+++ b/src/main/java/nl/tudelft/jpacman/annotations/ParameterizedAssignment.java
@@ -8,11 +8,13 @@ import java.lang.annotation.RetentionPolicy;
  *
  * A Students Solution class for the boundary testing exercise should have the following:
  *
- * @ParameterizedAssignment
- * @RunWith(Parameterized.class)
+ * <pre class="code"><code class="java">
+ * &#064;ParameterizedAssignment
+ * &#064;RunWith(Parameterized.class)
  * public class WithinBordersTest {
  *     //tests
  * }
+ * </code></pre>
  */
 @Retention(RetentionPolicy.CLASS)
 public @interface ParameterizedAssignment {


### PR DESCRIPTION
This correctly renders the example in a code block.
Also fixed the `@` as the JavaDoc would generate a warning that it could not find these annotations. They should be replaced with the encoded value instead.

Result:
![image](https://cloud.githubusercontent.com/assets/5948271/14761455/7d32663c-0962-11e6-87bd-ef15440b1c2b.png)
