### PR TITLE
Drop Hamcrest in favor of AssertJ

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,8 +7,8 @@
 	<version>6.4.0</version>
 	<url>https://github.com/serg-delft/jpacman-framework</url>
 	<description>
-        Pacman-inspired game, for teaching testing purposes.
-    </description>
+		Pacman-inspired game, for teaching testing purposes.
+	</description>
 	<organization>
 		<url>http://www.tudelft.nl</url>
 		<name>Delft University of Technology</name>
@@ -45,20 +45,24 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-		<junit.version>4.12</junit.version>
-		<mockito.version>2.0.47-beta</mockito.version>
-		<hamcrest.version>1.3</hamcrest.version>
 		<cucumber.version>1.2.4</cucumber.version>
+		<assertj.version>3.4.1</assertj.version>
+		<junit.version>4.12</junit.version>
+		<mockito.version>2.0.50-beta</mockito.version>
 
-		<surefire.plugin.version>2.19.1</surefire.plugin.version>
-		<javadoc.plugin.version>2.10.3</javadoc.plugin.version>
-		<projectinfo.plugin.version>2.9</projectinfo.plugin.version>
 		<assembly.plugin.version>2.6</assembly.plugin.version>
 		<checkstyle.plugin.version>2.17</checkstyle.plugin.version>
-		<pmd.plugin.version>3.6</pmd.plugin.version>
-		<findbugs.plugin.version>3.0.3</findbugs.plugin.version>
 		<cobertura.plugin.version>2.7</cobertura.plugin.version>
+		<findbugs.plugin.version>3.0.3</findbugs.plugin.version>
+		<guava.plugin.version>19.0</guava.plugin.version>
 		<jacoco.plugin.version>0.7.6.201602180812</jacoco.plugin.version>
+		<jar.plugin.version>2.6</jar.plugin.version>
+		<jxr.plugin.version>2.5</jxr.plugin.version>
+		<javadoc.plugin.version>2.10.3</javadoc.plugin.version>
+		<projectinfo.plugin.version>2.9</projectinfo.plugin.version>
+		<pmd.plugin.version>3.6</pmd.plugin.version>
+		<shade.plugin.version>2.4.3</shade.plugin.version>
+		<surefire.plugin.version>2.19.1</surefire.plugin.version>
 	</properties>
 
 	<dependencies>
@@ -66,23 +70,23 @@
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
 			<version>${junit.version}</version>
-            <scope>test</scope>
+			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
-			<version>19.0</version>
+			<version>${guava.plugin.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-core</artifactId>
 			<version>${mockito.version}</version>
-	        <scope>test</scope>
+			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.hamcrest</groupId>
-			<artifactId>hamcrest-library</artifactId>
-			<version>${hamcrest.version}</version>
+			<groupId>org.assertj</groupId>
+			<artifactId>assertj-core</artifactId>
+			<version>${assertj.version}</version>
 			<scope>test</scope>
 		</dependency>
 
@@ -98,7 +102,6 @@
 			<version>${cucumber.version}</version>
 			<scope>test</scope>
 		</dependency>
-
 	</dependencies>
 
 	<build>
@@ -124,7 +127,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-jar-plugin</artifactId>
-				<version>2.6</version>
+				<version>${jar.plugin.version}</version>
 				<configuration>
 					<useDefaultManifestFile>true</useDefaultManifestFile>
 				</configuration>
@@ -144,8 +147,8 @@
 				</executions>
 			</plugin>
 
-			<!-- The checkstyle, findbugs and PMD plugins have configurations, for 
-				the checkstyle:checkstyle and pmd:pmd to work properly, the plugins should 
+			<!-- The checkstyle, findbugs and PMD plugins have configurations, for
+				the checkstyle:checkstyle and pmd:pmd to work properly, the plugins should
 				also be specified under the build section. See: https://github.com/sevntu-checkstyle/checkstyle-samples/blob/master/maven-project/pom.xml -->
 
 			<plugin>
@@ -180,17 +183,17 @@
 					<includeTests>true</includeTests>
 				</configuration>
 			</plugin>
-			
-			<plugin> 
+
+			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
 				<version>${surefire.plugin.version}</version>
 			</plugin>
-			
+
 			<plugin>
-			    <groupId>org.jacoco</groupId>
-    			<artifactId>jacoco-maven-plugin</artifactId>
-    			<version>0.7.6.201602180812</version>
+				<groupId>org.jacoco</groupId>
+				<artifactId>jacoco-maven-plugin</artifactId>
+				<version>${jacoco.plugin.version}</version>
 				<executions>
 					<execution>
 						<id>default-prepare-agent</id>
@@ -212,27 +215,27 @@
 						</goals>
 						<configuration>
 							<haltOnFailure>false</haltOnFailure>
-              				<rules>
-			                	<rule>
-                  					<element>BUNDLE</element>
-                 					<limits>
-                     					<limit>
-                      						<counter>LINE</counter>
-                      						<value>COVEREDRATIO</value>
-                      						<minimum>0.60</minimum>
-                    					</limit>
-                  					</limits>
-                				</rule>
-              				</rules>
-            			</configuration>
+			  				<rules>
+								<rule>
+				  					<element>BUNDLE</element>
+				 					<limits>
+					 					<limit>
+					  						<counter>LINE</counter>
+					  						<value>COVEREDRATIO</value>
+					  						<minimum>0.60</minimum>
+										</limit>
+				  					</limits>
+								</rule>
+			  				</rules>
+						</configuration>
 					</execution>
 				</executions>
 			</plugin>
-				
+
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-shade-plugin</artifactId>
-				<version>2.4.3</version>
+				<version>${shade.plugin.version}</version>
 				<executions>
 					<execution>
 						<phase>package</phase>
@@ -247,6 +250,7 @@
 			</plugin>
 		</plugins>
 	</build>
+
 
 	<reporting>
 		<plugins>
@@ -276,16 +280,10 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-jxr-plugin</artifactId>
+				<version>${jxr.plugin.version}</version>
 				<configuration>
 					<linkJavadoc>true</linkJavadoc>
 				</configuration>
-				<version>2.5</version>
-			</plugin>
-
-			<plugin> <!-- JUnit report -->
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-surefire-report-plugin</artifactId>
-				<version>${surefire.plugin.version}</version>
 			</plugin>
 
 			<plugin>
@@ -295,9 +293,15 @@
 			</plugin>
 
 			<plugin>
-			    <groupId>org.jacoco</groupId>
-    			<artifactId>jacoco-maven-plugin</artifactId>
-    			<version>${jacoco.plugin.version}</version>
+				<groupId>org.jacoco</groupId>
+				<artifactId>jacoco-maven-plugin</artifactId>
+				<version>${jacoco.plugin.version}</version>
+			</plugin>
+
+			<plugin> <!-- JUnit report -->
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-report-plugin</artifactId>
+				<version>${surefire.plugin.version}</version>
 			</plugin>
 
 			<plugin>

--- a/src/test/java/nl/tudelft/jpacman/board/OccupantTest.java
+++ b/src/test/java/nl/tudelft/jpacman/board/OccupantTest.java
@@ -1,9 +1,7 @@
 package nl.tudelft.jpacman.board;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.Matchers.contains;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -45,8 +43,8 @@ public class OccupantTest {
 	public void testOccupy() {
 		Square target = new BasicSquare();
 		unit.occupy(target);
-		assertThat(unit.getSquare(), is(target));
-		assertThat(target.getOccupants(), contains(unit));
+		assertThat(unit.getSquare()).isEqualTo(target);
+		assertThat(target.getOccupants()).contains(unit);
 	}
 	
     /**
@@ -58,7 +56,7 @@ public class OccupantTest {
 		Square target = new BasicSquare();
 		unit.occupy(target);
 		unit.occupy(target);
-		assertThat(unit.getSquare(), is(target));
-		assertThat(target.getOccupants(), contains(unit));
+		assertThat(unit.getSquare()).isEqualTo(target);
+		assertThat(target.getOccupants()).contains(unit);
 	}
 }


### PR DESCRIPTION
[Hamcrest plugin](http://mvnrepository.com/artifact/org.hamcrest/hamcrest-library) has not been updated since 2012, the [AssertJ plugin](http://mvnrepository.com/artifact/org.assertj/assertj-core) is a well-known and up-to-date replacement.

The other changes are indentation fixes and extracted versions for easier management of plugins.
