### PR TITLE
[WIP] Update Travis configuration to fail on warnings/violations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,13 @@
 language: java
+sudo: false
 before_install:
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"
 jdk:
   - oraclejdk8
-script: "mvn clean test"
+env:
+  - COMMAND=test
+  - COMMAND=checkstyle:check
+  - COMMAND=pmd:check
+  - COMMAND="install -D skipTests=true findbugs:check"
+script: "mvn clean $COMMAND"

--- a/pom.xml
+++ b/pom.xml
@@ -155,6 +155,8 @@
 				<configuration>
 					<configLocation>${basedir}/checkstyle.xml</configLocation>
 					<includeTestSourceDirectory>true</includeTestSourceDirectory>
+					<failOnViolation>true</failOnViolation>
+					<violationSeverity>warning</violationSeverity>
 				</configuration>
 			</plugin>
 
@@ -308,12 +310,6 @@
 					<configLocation>${basedir}/checkstyle.xml</configLocation>
 					<includeTestSourceDirectory>true</includeTestSourceDirectory>
 				</configuration>
-			</plugin>
-
-			<plugin>
-				<groupId>org.codehaus.mojo</groupId>
-				<artifactId>findbugs-maven-plugin</artifactId>
-				<version>${findbugs.plugin.version}</version>
 			</plugin>
 
 			<plugin>

--- a/src/main/java/nl/tudelft/jpacman/Launcher.java
+++ b/src/main/java/nl/tudelft/jpacman/Launcher.java
@@ -144,7 +144,7 @@ public class Launcher {
 
 	/**
 	 * Adds key events UP, DOWN, LEFT and RIGHT to a game.
-	 * 
+	 *
 	 * @param builder
 	 *            The {@link PacManUiBuilder} that will provide the UI.
 	 * @param game


### PR DESCRIPTION
Do not merge yet. Must make sure that this PR is compatible with #80 .

This pull request should make Travis fail on warnings generated by the plugins. Current master has all errors fixed, so we should be able to keep up with all errors quite easily now.

Checkstyle:
![image](https://cloud.githubusercontent.com/assets/5948271/14762491/fd15bd2c-097b-11e6-879a-ef7d6710f4a6.png)
https://travis-ci.org/SERG-Delft/jpacman-framework/jobs/125239738#L1291

PMD:
![image](https://cloud.githubusercontent.com/assets/5948271/14762496/28c5a0ea-097c-11e6-9351-d6429d0a2e95.png)
https://travis-ci.org/SERG-Delft/jpacman-framework/jobs/125239739#L1523

Findbugs:
![image](https://cloud.githubusercontent.com/assets/5948271/14762488/e70d68a4-097b-11e6-96fa-d088f18b6f4b.png)
https://travis-ci.org/SERG-Delft/jpacman-framework/jobs/125239740#L1573-L1576

Also adds the container configuration of the new Travis builds.

![image](https://cloud.githubusercontent.com/assets/5948271/14762487/da094d30-097b-11e6-8ac4-75f046c66c5f.png)

Fixes #57 
