### PR TITLE
Fix reference error in scenarios

### DIFF
--- a/doc/scenarios.md
+++ b/doc/scenarios.md
@@ -91,7 +91,7 @@ When  I press an arrow key towards that square;
 Then  my Pacman dies,
  and  the game is over.
   
-Scenario S2.5: Player wins, extends S2.2
+Scenario S2.5: Player wins, extends S2.1
 When  I have eaten the last pellet;
 Then  I win the game.
 ```


### PR DESCRIPTION
Eating the pellet is performed in scenario 2.1 instead of 2.2.
