### PR TITLE
Fix cucumber tests messing with tests of dependants

### DIFF
--- a/src/test/java/nl/tudelft/jpacman/cucumber/StateNavigationSteps.java
+++ b/src/test/java/nl/tudelft/jpacman/cucumber/StateNavigationSteps.java
@@ -67,7 +67,7 @@ public class StateNavigationSteps {
 	/**
 	 * Close the UI after all tests are finished.
 	 */
-	@After
+	@After("@Framework")
 	public void tearDownUI() {
 		launcher.dispose();
 	}

--- a/src/test/resources/features/startup.feature
+++ b/src/test/resources/features/startup.feature
@@ -1,3 +1,4 @@
+@Framework
 Feature: 1. Startup
 	As a player
 	I want to start the game


### PR DESCRIPTION
The cucumber @after hook was messing with the tests in projects depending
on this framework. Because the @after hook is run after every scenario
dependants had to either overwrite the file by including a file with the same name
at the same place or do something equally ugly.

By tagging the hook and the only scenario included in the framework with the
"@Framework" tag the hook is only ran for that scenario. Thus the hook is not
ran in tests in projects depending on this one while not influencing the testing in
this project.

fixes #83 
