### PR TITLE
Make put() in Square public

### DIFF
--- a/src/main/java/nl/tudelft/jpacman/board/Square.java
+++ b/src/main/java/nl/tudelft/jpacman/board/Square.java
@@ -78,7 +78,7 @@ public abstract class Square {
 	 * @param occupant
 	 *            The unit to occupy this square.
 	 */
-	void put(Unit occupant) {
+	public void put(Unit occupant) {
 		assert occupant != null;
 		assert !occupants.contains(occupant);
 		


### PR DESCRIPTION
As students following the SKT course, we want to use the `put()` method in
the Square class to put special items (such as a strawberry or a melon) on
a map to enhance the functionality of the game. However, because `put()` was
protected we could not use it, a simple solution is to make `put()` public.

Our student details:
Eric Cornelissen; netid: ecornelissen; studentid: 4447859
Cornel de Vroomen; netid: cdevroomen; studentid: 4488628