### PR TITLE
Adopt Checker Framework

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,8 @@
 		<pmd.plugin.version>3.6</pmd.plugin.version>
 		<shade.plugin.version>2.4.3</shade.plugin.version>
 		<surefire.plugin.version>2.19.1</surefire.plugin.version>
+
+		<annotatedJdk>${org.checkerframework:jdk8:jar}</annotatedJdk>
 	</properties>
 
 	<dependencies>
@@ -112,10 +114,62 @@
 			<version>${cucumber.version}</version>
 			<scope>test</scope>
 		</dependency>
+
+		<!-- annotations from the Checker Framework: nullness, interning, locking, ... -->
+		<dependency>
+			<groupId>org.checkerframework</groupId>
+			<artifactId>checker-qual</artifactId>
+			<version>2.1.10</version>
+		</dependency>
+		<dependency>
+			<groupId>org.checkerframework</groupId>
+			<artifactId>checker</artifactId>
+			<version>2.1.10</version>
+		</dependency>
+		<!-- The annotated JDK to use (change to jdk7 if using Java 7). -->
+		<dependency>
+			<groupId>org.checkerframework</groupId>
+			<artifactId>jdk8</artifactId>
+			<version>2.1.10</version>
+		</dependency>
+
 	</dependencies>
 
 	<build>
 		<plugins>
+			<plugin>
+				<!-- This plugin will set properties values using dependency information -->
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-dependency-plugin</artifactId>
+				<version>2.3</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>properties</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+
+			<plugin>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.3</version>
+				<configuration>
+					<source>1.8</source>
+					<target>1.8</target>
+					<fork>true</fork>
+					<annotationProcessors>
+						<annotationProcessor>org.checkerframework.checker.nullness.NullnessChecker</annotationProcessor>
+					</annotationProcessors>
+					<compilerArgs>
+						<arg>-Xbootclasspath/p:${annotatedJdk}</arg>
+						<arg>-AskipUses=^java</arg>
+						<arg>-AassumeAssertionsAreEnabled</arg>
+					</compilerArgs>
+				</configuration>
+			</plugin>
+
+
 			<plugin>
 				<artifactId>maven-assembly-plugin</artifactId>
 				<version>${assembly.plugin.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,8 @@
 
         <assembly.plugin.version>2.6</assembly.plugin.version>
 		<checkstyle.plugin.version>2.17</checkstyle.plugin.version>
+		<compiler.plugin.version>3.3</compiler.plugin.version>
+		<dependency.plugin.version>2.3</dependency.plugin.version>
 		<findbugs.plugin.version>3.0.3</findbugs.plugin.version>
 		<guava.plugin.version>21.0</guava.plugin.version>
 		<jacoco.plugin.version>0.7.6.201602180812</jacoco.plugin.version>
@@ -68,6 +70,9 @@
 		<shade.plugin.version>2.4.3</shade.plugin.version>
 		<surefire.plugin.version>2.19.1</surefire.plugin.version>
 
+		<checkerframework.plugin.version>2.1.10</checkerframework.plugin.version>
+		<!-- IntelliJ will warn about this line, but the maven-dependency-plugin
+		     does correctly resolve this, so there is nothing to worry about. -->
 		<annotatedJdk>${org.checkerframework:jdk8:jar}</annotatedJdk>
 	</properties>
 
@@ -145,18 +150,18 @@
 		<dependency>
 			<groupId>org.checkerframework</groupId>
 			<artifactId>checker-qual</artifactId>
-			<version>2.1.10</version>
+			<version>${checkerframework.plugin.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.checkerframework</groupId>
 			<artifactId>checker</artifactId>
-			<version>2.1.10</version>
+			<version>${checkerframework.plugin.version}</version>
 		</dependency>
 		<!-- The annotated JDK to use (change to jdk7 if using Java 7). -->
 		<dependency>
 			<groupId>org.checkerframework</groupId>
 			<artifactId>jdk8</artifactId>
-			<version>2.1.10</version>
+			<version>${checkerframework.plugin.version}</version>
 		</dependency>
 
 	</dependencies>
@@ -167,7 +172,7 @@
 				<!-- This plugin will set properties values using dependency information -->
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-dependency-plugin</artifactId>
-				<version>2.3</version>
+				<version>${dependency.plugin.version}</version>
 				<executions>
 					<execution>
 						<goals>
@@ -179,10 +184,10 @@
 
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.3</version>
+				<version>${compiler.plugin.version}</version>
 				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
+					<source>${maven.compiler.source}</source>
+					<target>${maven.compiler.target}</target>
 					<fork>true</fork>
 					<annotationProcessors>
 						<annotationProcessor>org.checkerframework.checker.nullness.NullnessChecker</annotationProcessor>

--- a/src/main/java/nl/tudelft/jpacman/Launcher.java
+++ b/src/main/java/nl/tudelft/jpacman/Launcher.java
@@ -87,10 +87,15 @@ public class Launcher {
 	 */
 	public Level makeLevel() {
 		MapParser parser = getMapParser();
-		try (InputStream boardStream = Launcher.class.getResourceAsStream(getLevelMap())) {
-			return parser.parseMap(boardStream);
+		String mapName = getLevelMap();
+		try (InputStream boardStream = Launcher.class.getResourceAsStream(mapName)) {
+			if (boardStream != null) {
+				return parser.parseMap(boardStream);
+			} else {
+				throw new PacmanConfigurationException("Could not get resource for: " + mapName);
+			}
 		} catch (IOException e) {
-			throw new PacmanConfigurationException("Unable to create level.", e);
+			throw new PacmanConfigurationException("Unable to create level, name = " + mapName, e);
 		}
 	}
 

--- a/src/main/java/nl/tudelft/jpacman/Launcher.java
+++ b/src/main/java/nl/tudelft/jpacman/Launcher.java
@@ -19,6 +19,8 @@ import nl.tudelft.jpacman.sprite.PacManSprites;
 import nl.tudelft.jpacman.ui.Action;
 import nl.tudelft.jpacman.ui.PacManUI;
 import nl.tudelft.jpacman.ui.PacManUiBuilder;
+import org.checkerframework.checker.nullness.qual.EnsuresNonNull;
+import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 
 /**
  * Creates and launches the JPacMan UI.
@@ -34,13 +36,13 @@ public class Launcher {
 	private String levelMap = DEFAULT_MAP;
 
 	private PacManUI pacManUI;
-	private Game game;
+	@MonotonicNonNull private Game game;
 
 	/**
 	 * @return The game object this launcher will start when {@link #launch()}
 	 *         is called.
 	 */
-	public Game getGame() {
+	@MonotonicNonNull public Game getGame() {
 		return game;
 	}
 
@@ -73,7 +75,8 @@ public class Launcher {
 	public Game makeGame() {
 		GameFactory gf = getGameFactory();
 		Level level = makeLevel();
-		return gf.createSinglePlayerGame(level);
+		game = gf.createSinglePlayerGame(level);
+		return game;
 	}
 
 	/**
@@ -148,24 +151,20 @@ public class Launcher {
 	 * 
 	 * @param builder
 	 *            The {@link PacManUiBuilder} that will provide the UI.
-	 * @param game
-	 *            The game that will process the events.
 	 */
-	protected void addSinglePlayerKeys(final PacManUiBuilder builder, final Game game) {
-		final Player p1 = getSinglePlayer(game);
-
-		builder.addKey(KeyEvent.VK_UP, moveTowardsDirection(game, p1, Direction.NORTH))
-				.addKey(KeyEvent.VK_DOWN, moveTowardsDirection(game, p1, Direction.SOUTH))
-				.addKey(KeyEvent.VK_LEFT, moveTowardsDirection(game, p1, Direction.WEST))
-				.addKey(KeyEvent.VK_RIGHT, moveTowardsDirection(game, p1, Direction.EAST));
+	protected void addSinglePlayerKeys(final PacManUiBuilder builder) {
+		builder.addKey(KeyEvent.VK_UP, moveTowardsDirection(Direction.NORTH))
+				.addKey(KeyEvent.VK_DOWN, moveTowardsDirection(Direction.SOUTH))
+				.addKey(KeyEvent.VK_LEFT, moveTowardsDirection(Direction.WEST))
+				.addKey(KeyEvent.VK_RIGHT, moveTowardsDirection(Direction.EAST));
 	}
 
-	private Action moveTowardsDirection(final Game game, final Player p1, Direction direction) {
+	private Action moveTowardsDirection(Direction direction) {
 		return new Action() {
 
 			@Override
 			public void doAction() {
-				game.move(p1, direction);
+				getGame().move(getSinglePlayer(getGame()), direction);
 			}
 		};
 	}
@@ -181,11 +180,12 @@ public class Launcher {
 	/**
 	 * Creates and starts a JPac-Man game.
 	 */
+	@EnsuresNonNull("game")
 	public void launch() {
-		game = makeGame();
+		makeGame();
 		PacManUiBuilder builder = new PacManUiBuilder().withDefaultButtons();
-		addSinglePlayerKeys(builder, game);
-		pacManUI = builder.build(game);
+		addSinglePlayerKeys(builder);
+		pacManUI = builder.build(getGame());
 		pacManUI.start();
 	}
 

--- a/src/main/java/nl/tudelft/jpacman/Launcher.java
+++ b/src/main/java/nl/tudelft/jpacman/Launcher.java
@@ -19,7 +19,6 @@ import nl.tudelft.jpacman.sprite.PacManSprites;
 import nl.tudelft.jpacman.ui.Action;
 import nl.tudelft.jpacman.ui.PacManUI;
 import nl.tudelft.jpacman.ui.PacManUiBuilder;
-import org.checkerframework.checker.nullness.qual.EnsuresNonNull;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 
 /**
@@ -35,14 +34,15 @@ public class Launcher {
 	public static final String DEFAULT_MAP = "/board.txt";
 	private String levelMap = DEFAULT_MAP;
 
-	private PacManUI pacManUI;
+	@MonotonicNonNull private PacManUI pacManUI;
 	@MonotonicNonNull private Game game;
 
 	/**
 	 * @return The game object this launcher will start when {@link #launch()}
 	 *         is called.
 	 */
-	@MonotonicNonNull public Game getGame() {
+	public Game getGame() {
+		assert game != null;
 		return game;
 	}
 
@@ -180,7 +180,6 @@ public class Launcher {
 	/**
 	 * Creates and starts a JPac-Man game.
 	 */
-	@EnsuresNonNull("game")
 	public void launch() {
 		makeGame();
 		PacManUiBuilder builder = new PacManUiBuilder().withDefaultButtons();
@@ -192,8 +191,11 @@ public class Launcher {
 	/**
 	 * Disposes of the UI. For more information see
 	 * {@link javax.swing.JFrame#dispose()}.
+	 *
+	 * Precondition: The game was launched first.
 	 */
 	public void dispose() {
+		assert pacManUI != null;
 		pacManUI.dispose();
 	}
 

--- a/src/main/java/nl/tudelft/jpacman/board/Board.java
+++ b/src/main/java/nl/tudelft/jpacman/board/Board.java
@@ -1,7 +1,5 @@
 package nl.tudelft.jpacman.board;
 
-import org.checkerframework.checker.initialization.qual.UnderInitialization;
-
 /**
  * A top-down view of a matrix of {@link Square}s.
  * 

--- a/src/main/java/nl/tudelft/jpacman/board/Board.java
+++ b/src/main/java/nl/tudelft/jpacman/board/Board.java
@@ -1,5 +1,7 @@
 package nl.tudelft.jpacman.board;
 
+import org.checkerframework.checker.initialization.qual.UnderInitialization;
+
 /**
  * A top-down view of a matrix of {@link Square}s.
  * 
@@ -29,7 +31,7 @@ public class Board {
 	 * Whatever happens, the squares on the board can't be null.
 	 * @return false if any square on the board is null.
 	 */
-	protected final boolean invariant() {
+	protected final boolean invariant(@UnderInitialization Board this) {
 		for (Square[] row : board) {
 			for (Square square : row) {
 				if (square == null) {

--- a/src/main/java/nl/tudelft/jpacman/board/Board.java
+++ b/src/main/java/nl/tudelft/jpacman/board/Board.java
@@ -21,6 +21,7 @@ public class Board {
 	 *            The grid of squares with grid[x][y] being the square at column
 	 *            x, row y.
 	 */
+	@SuppressWarnings("initialization") // invariant uses fields set in constructor.
 	Board(Square[][] grid) {
 		assert grid != null;
 		this.board = grid;
@@ -31,7 +32,7 @@ public class Board {
 	 * Whatever happens, the squares on the board can't be null.
 	 * @return false if any square on the board is null.
 	 */
-	protected final boolean invariant(@UnderInitialization Board this) {
+	protected final boolean invariant() {
 		for (Square[] row : board) {
 			for (Square square : row) {
 				if (square == null) {
@@ -62,6 +63,9 @@ public class Board {
 
 	/**
 	 * Returns the square at the given <code>x,y</code> position.
+	 *
+	 * Precondition: The <code>(x, y)</code> coordinates are within the
+	 * width and height of the board.
 	 * 
 	 * @param x
 	 *            The <code>x</code> position (column) of the requested square.

--- a/src/main/java/nl/tudelft/jpacman/board/Square.java
+++ b/src/main/java/nl/tudelft/jpacman/board/Square.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import com.google.common.collect.ImmutableList;
 
 import nl.tudelft.jpacman.sprite.Sprite;
+import org.checkerframework.checker.initialization.qual.UnderInitialization;
 
 /**
  * A square on a {@link Board}, which can (or cannot, depending on the type) be
@@ -103,9 +104,9 @@ public abstract class Square {
 	 * @return <code>true</code> iff all occupants of this square have this
 	 *         square listed as the square they are currently occupying.
 	 */
-	protected final boolean invariant() {
+	protected final boolean invariant(@UnderInitialization Square this) {
 		for (Unit occupant : occupants) {
-			if (occupant.getSquare() != this) {
+			if (occupant.hasSquare() && occupant.getSquare() != this) {
 				return false;
 			}
 		}

--- a/src/main/java/nl/tudelft/jpacman/board/Square.java
+++ b/src/main/java/nl/tudelft/jpacman/board/Square.java
@@ -8,7 +8,6 @@ import java.util.Map;
 import com.google.common.collect.ImmutableList;
 
 import nl.tudelft.jpacman.sprite.Sprite;
-import org.checkerframework.checker.initialization.qual.UnderInitialization;
 
 /**
  * A square on a {@link Board}, which can (or cannot, depending on the type) be
@@ -31,6 +30,7 @@ public abstract class Square {
 	/**
 	 * Creates a new, empty square.
 	 */
+	@SuppressWarnings("initialization")
 	protected Square() {
 		this.occupants = new ArrayList<>();
 		this.neighbours = new EnumMap<>(Direction.class);
@@ -104,7 +104,7 @@ public abstract class Square {
 	 * @return <code>true</code> iff all occupants of this square have this
 	 *         square listed as the square they are currently occupying.
 	 */
-	protected final boolean invariant(@UnderInitialization Square this) {
+	protected final boolean invariant() {
 		for (Unit occupant : occupants) {
 			if (occupant.hasSquare() && occupant.getSquare() != this) {
 				return false;

--- a/src/main/java/nl/tudelft/jpacman/board/Unit.java
+++ b/src/main/java/nl/tudelft/jpacman/board/Unit.java
@@ -1,6 +1,7 @@
 package nl.tudelft.jpacman.board;
 
 import nl.tudelft.jpacman.sprite.Sprite;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * A unit that can be placed on a {@link Square}.
@@ -12,7 +13,7 @@ public abstract class Unit {
 	/**
 	 * The square this unit is currently occupying.
 	 */
-	private Square square;
+	@Nullable private Square square;
 	
 	/**
 	 * The direction this unit is facing.
@@ -50,7 +51,17 @@ public abstract class Unit {
 	 */
 	public Square getSquare() {
 		assert invariant();
+		assert square != null;
 		return square;
+	}
+
+	/**
+	 * Returns whether this unit is currently on  a square.
+	 *
+	 * @return True iff the unit is occupying a square at the moment.
+	 */
+	public boolean hasSquare() {
+		return square != null;
 	}
 
 	/**

--- a/src/main/java/nl/tudelft/jpacman/level/CollisionInteractionMap.java
+++ b/src/main/java/nl/tudelft/jpacman/level/CollisionInteractionMap.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Map;
 
 import nl.tudelft.jpacman.board.Unit;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * A map of possible collisions and their handlers.
@@ -128,6 +129,7 @@ public class CollisionInteractionMap implements CollisionMap {
 			return;
 		}
 
+		assert handlers.containsKey(colliderKey);
 		Map<Class<? extends Unit>, CollisionHandler<?, ?>> map = handlers
 				.get(colliderKey);
 		Class<? extends Unit> collideeKey = getMostSpecificClass(map,
@@ -155,7 +157,7 @@ public class CollisionInteractionMap implements CollisionMap {
 	 *            The class to search the most suitable key for.
 	 * @return The most specific class from the key collection.
 	 */
-	private Class<? extends Unit> getMostSpecificClass(
+	@Nullable private Class<? extends Unit> getMostSpecificClass(
 			Map<Class<? extends Unit>, ?> map, Class<? extends Unit> key) {
 		List<Class<? extends Unit>> collideeInheritance = getInheritance(key);
 		for (Class<? extends Unit> pointer : collideeInheritance) {

--- a/src/main/java/nl/tudelft/jpacman/level/Level.java
+++ b/src/main/java/nl/tudelft/jpacman/level/Level.java
@@ -243,8 +243,10 @@ public class Level {
 	 * executed.
 	 */
 	private void stopNPCs() {
-		for (Entry<NPC, ScheduledExecutorService> e : npcs.entrySet()) {
-			e.getValue().shutdownNow();
+		for (Entry<NPC, @Nullable ScheduledExecutorService> e : npcs.entrySet()) {
+			ScheduledExecutorService schedule = e.getValue();
+			assert schedule != null;
+			schedule.shutdownNow();
 		}
 	}
 

--- a/src/main/java/nl/tudelft/jpacman/level/Level.java
+++ b/src/main/java/nl/tudelft/jpacman/level/Level.java
@@ -16,7 +16,6 @@ import nl.tudelft.jpacman.board.Direction;
 import nl.tudelft.jpacman.board.Square;
 import nl.tudelft.jpacman.board.Unit;
 import nl.tudelft.jpacman.npc.NPC;
-import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**

--- a/src/main/java/nl/tudelft/jpacman/level/Level.java
+++ b/src/main/java/nl/tudelft/jpacman/level/Level.java
@@ -16,6 +16,8 @@ import nl.tudelft.jpacman.board.Direction;
 import nl.tudelft.jpacman.board.Square;
 import nl.tudelft.jpacman.board.Unit;
 import nl.tudelft.jpacman.npc.NPC;
+import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * A level of Pac-Man. A level consists of the board with the players and the
@@ -45,7 +47,7 @@ public class Level {
 	/**
 	 * The NPCs of this level and, if they are running, their schedules.
 	 */
-	private final Map<NPC, ScheduledExecutorService> npcs;
+	private final Map<NPC, @Nullable ScheduledExecutorService> npcs;
 
 	/**
 	 * <code>true</code> iff this level is currently in progress, i.e. players
@@ -172,6 +174,7 @@ public class Level {
 	public void move(Unit unit, Direction direction) {
 		assert unit != null;
 		assert direction != null;
+		assert unit.hasSquare();
 
 		if (!isInProgress()) {
 			return;

--- a/src/main/java/nl/tudelft/jpacman/level/LevelFactory.java
+++ b/src/main/java/nl/tudelft/jpacman/level/LevelFactory.java
@@ -12,6 +12,7 @@ import nl.tudelft.jpacman.npc.ghost.GhostColor;
 import nl.tudelft.jpacman.npc.ghost.GhostFactory;
 import nl.tudelft.jpacman.sprite.PacManSprites;
 import nl.tudelft.jpacman.sprite.Sprite;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * Factory that creates levels and units.
@@ -134,7 +135,7 @@ public class LevelFactory {
 		}
 
 		@Override
-		public Direction nextMove() {
+		@Nullable public Direction nextMove() {
 			return randomMove();
 		}
 	}

--- a/src/main/java/nl/tudelft/jpacman/npc/NPC.java
+++ b/src/main/java/nl/tudelft/jpacman/npc/NPC.java
@@ -2,6 +2,7 @@ package nl.tudelft.jpacman.npc;
 
 import nl.tudelft.jpacman.board.Direction;
 import nl.tudelft.jpacman.board.Unit;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * A non-player unit.
@@ -20,10 +21,12 @@ public abstract class NPC extends Unit {
 	/**
 	 * Calculates the next move for this unit and returns the direction to move
 	 * in.
-	 * 
+	 *
+	 * Precondition: The NPC occupies a square (hasSquare() holds).
+	 *
 	 * @return The direction to move in, or <code>null</code> if no move could
 	 *         be devised.
 	 */
-	public abstract Direction nextMove();
+	@Nullable public abstract Direction nextMove();
 
 }

--- a/src/main/java/nl/tudelft/jpacman/npc/ghost/Blinky.java
+++ b/src/main/java/nl/tudelft/jpacman/npc/ghost/Blinky.java
@@ -5,8 +5,10 @@ import java.util.Map;
 
 import nl.tudelft.jpacman.board.Direction;
 import nl.tudelft.jpacman.board.Square;
+import nl.tudelft.jpacman.board.Unit;
 import nl.tudelft.jpacman.level.Player;
 import nl.tudelft.jpacman.sprite.Sprite;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * <p>
@@ -75,17 +77,19 @@ public class Blinky extends Ghost {
 	 * Blinky, he'll try to move up towards Pac-Man before he moves to the left.
 	 * </p>
 	 */
-	@Override
+	@Override @Nullable
 	public Direction nextMove() {
+		assert hasSquare();
+
 		// TODO Blinky should patrol his corner every once in a while
 		// TODO Implement his actual behaviour instead of simply chasing.
-		Square target = Navigation.findNearest(Player.class, getSquare())
-				.getSquare();
-
-		if (target == null) {
+		Unit nearest = Navigation.findNearest(Player.class, getSquare());
+		if (nearest == null) {
 			return randomMove();
 		}
-		
+		assert nearest.hasSquare();
+		Square target = nearest.getSquare();
+
 		List<Direction> path = Navigation.shortestPath(getSquare(), target,
 				this);
 		if (path != null && !path.isEmpty()) {

--- a/src/main/java/nl/tudelft/jpacman/npc/ghost/Clyde.java
+++ b/src/main/java/nl/tudelft/jpacman/npc/ghost/Clyde.java
@@ -6,8 +6,10 @@ import java.util.Map;
 
 import nl.tudelft.jpacman.board.Direction;
 import nl.tudelft.jpacman.board.Square;
+import nl.tudelft.jpacman.board.Unit;
 import nl.tudelft.jpacman.level.Player;
 import nl.tudelft.jpacman.sprite.Sprite;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * <p>
@@ -95,13 +97,16 @@ public class Clyde extends Ghost {
 	 * move in the opposite direction when he gets within 8 cells of Pac-Man.
 	 * </p>
 	 */
-	@Override
+	@Override @Nullable
 	public Direction nextMove() {
-		Square target = Navigation.findNearest(Player.class, getSquare())
-				.getSquare();
-		if (target == null) {
+		assert hasSquare();
+
+		Unit nearest = Navigation.findNearest(Player.class, getSquare());
+		if (nearest == null) {
 			return randomMove();
 		}
+		assert nearest.hasSquare();
+		Square target = nearest.getSquare();
 
 		List<Direction> path = Navigation.shortestPath(getSquare(), target,
 				this);

--- a/src/main/java/nl/tudelft/jpacman/npc/ghost/Ghost.java
+++ b/src/main/java/nl/tudelft/jpacman/npc/ghost/Ghost.java
@@ -9,6 +9,7 @@ import nl.tudelft.jpacman.board.Direction;
 import nl.tudelft.jpacman.board.Square;
 import nl.tudelft.jpacman.npc.NPC;
 import nl.tudelft.jpacman.sprite.Sprite;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * An antagonist in the game of Pac-Man, a ghost.
@@ -64,7 +65,7 @@ public abstract class Ghost extends NPC {
 	 * @return A direction in which the ghost can move, or <code>null</code> if
 	 *         the ghost is shut in by inaccessible squares.
 	 */
-	protected Direction randomMove() {
+	@Nullable protected Direction randomMove() {
 		Square square = getSquare();
 		List<Direction> directions = new ArrayList<>();
 		for (Direction d : Direction.values()) {

--- a/src/main/java/nl/tudelft/jpacman/npc/ghost/Inky.java
+++ b/src/main/java/nl/tudelft/jpacman/npc/ghost/Inky.java
@@ -8,6 +8,7 @@ import nl.tudelft.jpacman.board.Square;
 import nl.tudelft.jpacman.board.Unit;
 import nl.tudelft.jpacman.level.Player;
 import nl.tudelft.jpacman.sprite.Sprite;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * <p>
@@ -92,17 +93,20 @@ public class Inky extends Ghost {
 	 * </p>
 	 */
 	// CHECKSTYLE:OFF To keep this more readable.
-	@Override
+	@Override @Nullable
 	public Direction nextMove() {
+		assert hasSquare();
+
 		Unit blinky = Navigation.findNearest(Blinky.class, getSquare());
 		if (blinky == null) {
 			return randomMove();
 		}
 
-		Unit player = Navigation.findNearest(Player.class, getSquare());
+		@Nullable Unit player = Navigation.findNearest(Player.class, getSquare());
 		if (player == null) {
 			return randomMove();
 		}
+		assert player.hasSquare();
 
 		Direction targetDirection = player.getDirection();
 		Square playerDestination = player.getSquare();
@@ -111,7 +115,7 @@ public class Inky extends Ghost {
 		}
 
 		Square destination = playerDestination;
-		List<Direction> firstHalf = Navigation.shortestPath(blinky.getSquare(),
+		@Nullable List<Direction> firstHalf = Navigation.shortestPath(blinky.getSquare(),
 				playerDestination, null);
 		if (firstHalf == null) {
 			return randomMove();
@@ -121,7 +125,7 @@ public class Inky extends Ghost {
 			destination = playerDestination.getSquareAt(d);
 		}
 
-		List<Direction> path = Navigation.shortestPath(getSquare(),
+		@Nullable List<Direction> path = Navigation.shortestPath(getSquare(),
 				destination, this);
 		if (path != null && !path.isEmpty()) {
 			return path.get(0);

--- a/src/main/java/nl/tudelft/jpacman/npc/ghost/Navigation.java
+++ b/src/main/java/nl/tudelft/jpacman/npc/ghost/Navigation.java
@@ -8,6 +8,7 @@ import java.util.Set;
 import nl.tudelft.jpacman.board.Direction;
 import nl.tudelft.jpacman.board.Square;
 import nl.tudelft.jpacman.board.Unit;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * Navigation provides utility to nagivate on {@link Square}s.
@@ -38,8 +39,8 @@ public final class Navigation {
 	 *         such path could be found. When the destination is the current
 	 *         square, an empty list is returned.
 	 */
-	public static List<Direction> shortestPath(Square from, Square to,
-			Unit traveller) {
+	@Nullable public static List<Direction> shortestPath(Square from, Square to,
+			@Nullable  Unit traveller) {
 		if (from.equals(to)) {
 			return new ArrayList<>();
 		}
@@ -59,7 +60,7 @@ public final class Navigation {
 		return null;
 	}
 
-	private static void addNewTargets(Unit traveller, List<Node> targets,
+	private static void addNewTargets(@Nullable Unit traveller, List<Node> targets,
 			Set<Square> visited, Node n, Square s) {
 		for (Direction d : Direction.values()) {
 			Square target = s.getSquareAt(d);
@@ -83,7 +84,7 @@ public final class Navigation {
 	 * @return The nearest unit of the given type, or <code>null</code> if no
 	 *         such unit could be found.
 	 */
-	public static Unit findNearest(Class<? extends Unit> type,
+	@Nullable public static Unit findNearest(Class<? extends Unit> type,
 			Square currentLocation) {
 		List<Square> toDo = new ArrayList<>();
 		Set<Square> visited = new HashSet<>();
@@ -94,6 +95,7 @@ public final class Navigation {
 			Square square = toDo.remove(0);
 			Unit unit = findUnit(type, square);
 			if (unit != null) {
+				assert unit.hasSquare();
 				return unit;
 			}
 			visited.add(square);
@@ -117,9 +119,10 @@ public final class Navigation {
 	 * @return A unit of type T, iff such a unit occupies this square, or
 	 *         <code>null</code> of none does.
 	 */
-	public static Unit findUnit(Class<? extends Unit> type, Square square) {
+	@Nullable public static Unit findUnit(Class<? extends Unit> type, Square square) {
 		for (Unit u : square.getOccupants()) {
 			if (type.isInstance(u)) {
+				assert u.hasSquare();
 				return u;
 			}
 		}
@@ -137,12 +140,12 @@ public final class Navigation {
 		 * The direction for this node, which is <code>null</code> for the root
 		 * node.
 		 */
-		private final Direction direction;
+		@Nullable private final Direction direction;
 
 		/**
 		 * The parent node, which is <code>null</code> for the root node.
 		 */
-		private final Node parent;
+		@Nullable private final Node parent;
 
 		/**
 		 * The square associated with this node.
@@ -161,7 +164,7 @@ public final class Navigation {
 		 *            The parent node, which is <code>null</code> for the root
 		 *            node.
 		 */
-		Node(Direction d, Square s, Node p) {
+		Node(@Nullable Direction d, Square s, @Nullable Node p) {
 			this.direction = d;
 			this.square = s;
 			this.parent = p;
@@ -171,7 +174,7 @@ public final class Navigation {
 		 * @return The direction for this node, or <code>null</code> if this
 		 *         node is a root node.
 		 */
-		private Direction getDirection() {
+		@Nullable private Direction getDirection() {
 			return direction;
 		}
 
@@ -186,7 +189,7 @@ public final class Navigation {
 		 * @return The parent node, or <code>null</code> if this node is a root
 		 *         node.
 		 */
-		private Node getParent() {
+		@Nullable private Node getParent() {
 			return parent;
 		}
 

--- a/src/main/java/nl/tudelft/jpacman/npc/ghost/Navigation.java
+++ b/src/main/java/nl/tudelft/jpacman/npc/ghost/Navigation.java
@@ -199,7 +199,7 @@ public final class Navigation {
 		 * @return The list of values from the root of the tree to this node.
 		 */
 		private List<Direction> getPath() {
-			if (getParent() == null) {
+			if (parent == null) {
 				return new ArrayList<>();
 			}
 			List<Direction> path = parent.getPath();

--- a/src/main/java/nl/tudelft/jpacman/npc/ghost/Pinky.java
+++ b/src/main/java/nl/tudelft/jpacman/npc/ghost/Pinky.java
@@ -8,6 +8,7 @@ import nl.tudelft.jpacman.board.Square;
 import nl.tudelft.jpacman.board.Unit;
 import nl.tudelft.jpacman.level.Player;
 import nl.tudelft.jpacman.sprite.Sprite;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * <p>
@@ -85,12 +86,15 @@ public class Pinky extends Ghost {
 	 * spaces.
 	 * </p>
 	 */
-	@Override
+	@Override @Nullable
 	public Direction nextMove() {
+		assert hasSquare();
+
 		Unit player = Navigation.findNearest(Player.class, getSquare());
 		if (player == null) {
 			return randomMove();
 		}
+		assert player.hasSquare();
 
 		Direction targetDirection = player.getDirection();
 		Square destination = player.getSquare();
@@ -98,7 +102,7 @@ public class Pinky extends Ghost {
 			destination = destination.getSquareAt(targetDirection);
 		}
 
-		List<Direction> path = Navigation.shortestPath(getSquare(),
+		@Nullable List<Direction> path = Navigation.shortestPath(getSquare(),
 				destination, this);
 		if (path != null && !path.isEmpty()) {
 			return path.get(0);

--- a/src/main/java/nl/tudelft/jpacman/ui/PacManUI.java
+++ b/src/main/java/nl/tudelft/jpacman/ui/PacManUI.java
@@ -12,6 +12,7 @@ import javax.swing.JPanel;
 
 import nl.tudelft.jpacman.game.Game;
 import nl.tudelft.jpacman.ui.ScorePanel.ScoreFormatter;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * The default JPacMan UI frame. The PacManUI consists of the following
@@ -64,8 +65,9 @@ public class PacManUI extends JFrame {
 	 * @param sf
 	 *            The formatter used to display the current score. 
 	 */
+	@SuppressWarnings("initialization") // Due to extension of a JFrame.
 	public PacManUI(final Game game, final Map<String, Action> buttons,
-			final Map<Integer, Action> keyMappings, ScoreFormatter sf) {
+			final Map<Integer, Action> keyMappings, @Nullable ScoreFormatter sf) {
 		super("JPac-Man");
 		assert game != null;
 		assert buttons != null;

--- a/src/main/java/nl/tudelft/jpacman/ui/PacManUiBuilder.java
+++ b/src/main/java/nl/tudelft/jpacman/ui/PacManUiBuilder.java
@@ -6,6 +6,7 @@ import java.util.Map;
 
 import nl.tudelft.jpacman.game.Game;
 import nl.tudelft.jpacman.ui.ScorePanel.ScoreFormatter;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * Builder for the JPac-Man UI.
@@ -42,7 +43,7 @@ public class PacManUiBuilder {
 	/**
 	 * Way to format the score.
 	 */
-	private ScoreFormatter scoreFormatter = null;
+	@Nullable private ScoreFormatter scoreFormatter = null;
 
 	/**
 	 * Creates a new Pac-Man UI builder without any mapped keys or buttons.

--- a/src/test/java/nl/tudelft/jpacman/LauncherSmokeTest.java
+++ b/src/test/java/nl/tudelft/jpacman/LauncherSmokeTest.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.Test;
  *
  * @author Arie van Deursen, March 2014.
  */
-class LauncherSmokeTest {
+public class LauncherSmokeTest {
 	
 	private Launcher launcher;
 	
@@ -106,7 +106,7 @@ class LauncherSmokeTest {
      * @param dir The direction to be taken
      * @param numSteps The number of steps to take
      */
-    static void move(Game game, Direction dir, int numSteps) {
+    public static void move(Game game, Direction dir, int numSteps) {
         Player player = game.getPlayers().get(0);
         for (int i = 0; i < numSteps; i++) {
             game.move(player, dir);

--- a/src/test/java/nl/tudelft/jpacman/LauncherSmokeTest.java
+++ b/src/test/java/nl/tudelft/jpacman/LauncherSmokeTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
  *
  * @author Arie van Deursen, March 2014.
  */
+@SuppressWarnings("initialization")
 public class LauncherSmokeTest {
 	
 	private Launcher launcher;

--- a/src/test/java/nl/tudelft/jpacman/board/BasicSquare.java
+++ b/src/test/java/nl/tudelft/jpacman/board/BasicSquare.java
@@ -22,6 +22,7 @@ class BasicSquare extends Square {
 	}
 
 	@Override
+	@SuppressWarnings("return.type.incompatible")
 	public Sprite getSprite() {
 		return null;
 	}

--- a/src/test/java/nl/tudelft/jpacman/board/BasicUnit.java
+++ b/src/test/java/nl/tudelft/jpacman/board/BasicUnit.java
@@ -17,6 +17,7 @@ class BasicUnit extends Unit {
 	}
 
 	@Override
+	@SuppressWarnings("return.type.incompatible")
 	public Sprite getSprite() {
 		return null;
 	}

--- a/src/test/java/nl/tudelft/jpacman/board/BoardFactoryTest.java
+++ b/src/test/java/nl/tudelft/jpacman/board/BoardFactoryTest.java
@@ -14,6 +14,7 @@ import java.util.Arrays;
  * 
  * @author Jeroen Roosen 
  */
+@SuppressWarnings("initialization.fields.uninitialized")
 class BoardFactoryTest {
 
 	/**

--- a/src/test/java/nl/tudelft/jpacman/board/OccupantTest.java
+++ b/src/test/java/nl/tudelft/jpacman/board/OccupantTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Test;
  * @author Jeroen Roosen 
  * 
  */
+@SuppressWarnings("initialization")
 class OccupantTest {
 
 	/**

--- a/src/test/java/nl/tudelft/jpacman/board/OccupantTest.java
+++ b/src/test/java/nl/tudelft/jpacman/board/OccupantTest.java
@@ -31,7 +31,7 @@ class OccupantTest {
 	 */
 	@Test
 	void noStartSquare() {
-		assertThat(unit.getSquare()).isNull();
+		assertThat(unit.hasSquare()).isFalse();
 	}
 
 	/**

--- a/src/test/java/nl/tudelft/jpacman/board/SquareTest.java
+++ b/src/test/java/nl/tudelft/jpacman/board/SquareTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.mock;
  * 
  * @author Jeroen Roosen 
  */
+@SuppressWarnings("initialization.fields.uninitialized")
 class SquareTest {
 
 	/**

--- a/src/test/java/nl/tudelft/jpacman/cucumber/StateNavigationSteps.java
+++ b/src/test/java/nl/tudelft/jpacman/cucumber/StateNavigationSteps.java
@@ -17,6 +17,7 @@ import nl.tudelft.jpacman.game.Game;
  *
  * @author Jan-Willem Gmelig Meyling, Arie van Deursen
  */
+@SuppressWarnings("initialization.fields.uninitialized")
 public class StateNavigationSteps {
 	
 	private static Game theGame;

--- a/src/test/java/nl/tudelft/jpacman/level/LevelTest.java
+++ b/src/test/java/nl/tudelft/jpacman/level/LevelTest.java
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.Test;
  * @author Jeroen Roosen 
  */
 // The four suppress warnings ignore the same rule, which results in 4 same string literals
-@SuppressWarnings({"PMD.AvoidDuplicateLiterals", "PMD.TooManyStaticImports"})
+@SuppressWarnings({"PMD.AvoidDuplicateLiterals", "PMD.TooManyStaticImports", "initialization.fields.uninitialized"})
 class LevelTest {
 
 	/**

--- a/src/test/java/nl/tudelft/jpacman/level/LevelTest.java
+++ b/src/test/java/nl/tudelft/jpacman/level/LevelTest.java
@@ -20,7 +20,8 @@ import org.junit.jupiter.api.Test;
  * @author Jeroen Roosen 
  */
 // The four suppress warnings ignore the same rule, which results in 4 same string literals
-@SuppressWarnings({"PMD.AvoidDuplicateLiterals", "PMD.TooManyStaticImports", "initialization.fields.uninitialized"})
+@SuppressWarnings({"PMD.AvoidDuplicateLiterals", "PMD.TooManyStaticImports",
+	"initialization.fields.uninitialized"})
 class LevelTest {
 
 	/**

--- a/src/test/java/nl/tudelft/jpacman/npc/ghost/NavigationTest.java
+++ b/src/test/java/nl/tudelft/jpacman/npc/ghost/NavigationTest.java
@@ -28,7 +28,8 @@ import org.junit.jupiter.api.Test;
  * @author Jeroen Roosen
  *
  */
-@SuppressWarnings({"magicnumber", "PMD.AvoidDuplicateLiterals"})
+@SuppressWarnings({"magicnumber", "PMD.AvoidDuplicateLiterals",
+"initialization.fields.uninitialized", "argument.type.incompatible"})
 class NavigationTest {
 
 	/**
@@ -120,14 +121,16 @@ class NavigationTest {
 	 * Verifies that the nearest object is detected.
 	 */
 	@Test
+	@SuppressWarnings("dereference.of.nullable")
 	void testNearestUnit() {
 		Board b = parser
 				.parseMap(Lists.newArrayList("#####", "# ..#", "#####"))
 				.getBoard();
 		Square s1 = b.squareAt(1, 1);
 		Square s2 = b.squareAt(2, 1);
-		Square result = Navigation.findNearest(Pellet.class, s1).getSquare();
-		assertThat(result).isEqualTo(s2);
+		Unit nearestPellet = Navigation.findNearest(Pellet.class, s1);
+		assertThat(nearestPellet).isNotNull();
+		assertThat(nearestPellet.getSquare()).isEqualTo(s2);
 	}
 
 	/**

--- a/src/test/java/nl/tudelft/jpacman/sprite/SpriteTest.java
+++ b/src/test/java/nl/tudelft/jpacman/sprite/SpriteTest.java
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.Test;
  * 
  * @author Jeroen Roosen 
  */
-@SuppressWarnings("magicnumber")
+@SuppressWarnings({"magicnumber", "initialization.fields.uninitialized"})
 public class SpriteTest {
 
     private Sprite sprite;


### PR DESCRIPTION
This branch is the result of applying null checks as offered through the [Checker Framework](https://checkerframework.org/) to JPacman.

The checker framework's default assumption is that classes are non-nullable, so I added a couple of Nullable annotations where needed.

I also made some assumptions explicit through run time assertions (with the `assert` keyword), which the checkerframework then uses in its static analysis.

I suppressed all initialization warnings in the test classes (the checkerframework does not recognize JUnit (5) setup methods) -- and I could not find a way to disable null checking all test suites all together.

I made the `getSquare` method non-null, adding an explicit checker method for testing nullity which is then a precondition for `getSquare`.

Invariant methods invoked in the constructor lead to initialization problems from the checkerframework, which I eventually decided to suppress.

Potentially incorrectly unhandled null values occurred in the AI for determining next moves of ghosts, and in the handling of a resource in case of a reading failure.

This is a bit of a big bang pull request, since it is not so obvious how to enable null checking on just a few classes only.

After the null checks are integrated, we could consider adopting other checkerframework checks.

An open question is how this relates to Java 8 Optionals.

Insisting that students use the checkerframework in their own solutions is a decision that is separate from merging the pull request. The checkerframework does some deep analysis and requires thorough understanding of how Java works.