### PR TITLE
Fix pom so that JUnit5 M4 works with IntelliJ.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,33 @@
             <version>${junit.jupiter.version}</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-engine</artifactId>
+			<version>${junit.jupiter.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.vintage</groupId>
+			<artifactId>junit-vintage-engine</artifactId>
+			<version>${junit.vintage.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.platform</groupId>
+			<artifactId>junit-platform-runner</artifactId>
+			<version>${junit.platform.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.junit.platform</groupId>
+			<artifactId>junit-platform-launcher</artifactId>
+			<version>${junit.platform.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+
+		<dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>${junit.version}</version>


### PR DESCRIPTION
Fix by @LiamClark, based on
 https://youtrack.jetbrains.com/issue/IDEA-170817#comment=27-2081808

The latest version of intelij did fix some junit 5 interaction.
Although it doesn't package the correct dependencies itself yet,
we can override them. We supply m4 versions of the platform and vintage.

This makes intelij call into the correct code and everything works again.

Fix can probably reverted once IntelliJ offers long term solution.