### PR TITLE
Update checkstyle version used in cs plugin.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -255,6 +255,13 @@
 					<configLocation>${basedir}/checkstyle.xml</configLocation>
 					<includeTestSourceDirectory>true</includeTestSourceDirectory>
 				</configuration>
+				<dependencies>
+					<dependency>
+						<groupId>com.puppycrawl.tools</groupId>
+						<artifactId>checkstyle</artifactId>
+						<version>7.6.1</version>
+					</dependency>
+				</dependencies>
 			</plugin>
 
 			<plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,7 @@
 
         <assembly.plugin.version>2.6</assembly.plugin.version>
 		<checkstyle.plugin.version>2.17</checkstyle.plugin.version>
+		<checkstyle.version>7.6.1</checkstyle.version>
 		<compiler.plugin.version>3.3</compiler.plugin.version>
 		<dependency.plugin.version>2.3</dependency.plugin.version>
 		<findbugs.plugin.version>3.0.3</findbugs.plugin.version>
@@ -259,7 +260,7 @@
 					<dependency>
 						<groupId>com.puppycrawl.tools</groupId>
 						<artifactId>checkstyle</artifactId>
-						<version>7.6.1</version>
+						<version>${checkstyle.version}</version>
 					</dependency>
 				</dependencies>
 			</plugin>

--- a/src/main/java/nl/tudelft/jpacman/board/Board.java
+++ b/src/main/java/nl/tudelft/jpacman/board/Board.java
@@ -30,6 +30,10 @@ public class Board {
 	/**
 	 * Whatever happens, the squares on the board can't be null.
 	 * @return false if any square on the board is null.
+	 *
+	 * This method uses Java 8's possibility to make the receiver ("this") explicit,
+	 * so that it can be annotated for the Checker Framework to indicate that it
+	 * is called from the constructor, i.e., that the object "this" is still in the making.
 	 */
 	protected final boolean invariant(@UnderInitialization(Board.class) Board this) {
 		for (Square[] row : board) {


### PR DESCRIPTION
The standard Checkstyle version fails on annotated receiver parameters, as used for the checkerframework (as introduced in e.g. 9da1cb15b7c90973217fd2a46b7bf2ceba023b83).

This is a known and resolved issue in Checkstyle, see https://github.com/checkstyle/checkstyle/pull/3734

The solution is to upgrade Checkstyle to a version including that fix (e.g. 7.6.1).

This is not done by updating the maven plugin, but by setting the checkstyle version used within the checkstyle maven plugin configuration. https://maven.apache.org/plugins/maven-checkstyle-plugin/examples/upgrading-checkstyle.html