### PR TITLE
Fix Javadoc of Ground class

### DIFF
--- a/src/main/java/nl/tudelft/jpacman/board/BoardFactory.java
+++ b/src/main/java/nl/tudelft/jpacman/board/BoardFactory.java
@@ -109,7 +109,7 @@ public class BoardFactory {
 	}
 
 	/**
-	 * A wall is a square that is accessible to anyone.
+	 * A ground square is a square that is accessible to anyone.
 	 * 
 	 * @author Jeroen Roosen 
 	 */


### PR DESCRIPTION
Currently, the Ground class is incorrectly described as a wall in the Javadoc. This PR changes this to ground square to reflect the actual square type of the class.