### PR TITLE
Fix code style and remove unnecessary abbreviations

### DIFF
--- a/src/main/java/nl/tudelft/jpacman/Launcher.java
+++ b/src/main/java/nl/tudelft/jpacman/Launcher.java
@@ -92,11 +92,10 @@ public class Launcher {
 		MapParser parser = getMapParser();
 		String mapName = getLevelMap();
 		try (InputStream boardStream = Launcher.class.getResourceAsStream(mapName)) {
-			if (boardStream != null) {
-				return parser.parseMap(boardStream);
-			} else {
+			if (boardStream == null) {
 				throw new PacmanConfigurationException("Could not get resource for: " + mapName);
 			}
+			return parser.parseMap(boardStream);
 		} catch (IOException e) {
 			throw new PacmanConfigurationException("Unable to create level, name = " + mapName, e);
 		}

--- a/src/main/java/nl/tudelft/jpacman/board/Direction.java
+++ b/src/main/java/nl/tudelft/jpacman/board/Direction.java
@@ -31,13 +31,13 @@ public enum Direction {
 	 * The delta x (width difference) to an element in the direction in a grid
 	 * with 0,0 (x,y) as its top-left element.
 	 */
-	private final int dx;
+	private final int deltaX;
 
 	/**
 	 * The delta y (height difference) to an element in the direction in a grid
 	 * with 0,0 (x,y) as its top-left element.
 	 */
-	private final int dy;
+	private final int deltaY;
 
 	/**
 	 * Creates a new Direction with the given parameters.
@@ -50,8 +50,8 @@ public enum Direction {
 	 *            in a matrix with 0,0 (x,y) as its top-left element.
 	 */
 	Direction(int deltaX, int deltaY) {
-		this.dx = deltaX;
-		this.dy = deltaY;
+		this.deltaX = deltaX;
+		this.deltaY = deltaY;
 	}
 
 	/**
@@ -59,7 +59,7 @@ public enum Direction {
 	 *         direction, in a matrix with 0,0 (x,y) as its top-left element.
 	 */
 	public int getDeltaX() {
-		return dx;
+		return deltaX;
 	}
 
 	/**
@@ -67,6 +67,6 @@ public enum Direction {
 	 *         direction, in a matrix with 0,0 (x,y) as its top-left element.
 	 */
 	public int getDeltaY() {
-		return dy;
+		return deltaY;
 	}
 }

--- a/src/main/java/nl/tudelft/jpacman/game/Game.java
+++ b/src/main/java/nl/tudelft/jpacman/game/Game.java
@@ -39,8 +39,7 @@ public abstract class Game implements LevelObserver {
 			if (isInProgress()) {
 				return;
 			}
-			if (getLevel().isAnyPlayerAlive()
-					&& getLevel().remainingPellets() > 0) {
+			if (getLevel().isAnyPlayerAlive() && getLevel().remainingPellets() > 0) {
 				inProgress = true;
 				getLevel().addObserver(this);
 				getLevel().start();

--- a/src/main/java/nl/tudelft/jpacman/game/GameFactory.java
+++ b/src/main/java/nl/tudelft/jpacman/game/GameFactory.java
@@ -13,7 +13,7 @@ public class GameFactory {
 	/**
 	 * The factory providing the player objects.
 	 */
-	private final PlayerFactory playerFact;
+	private final PlayerFactory playerFactory;
 
 	/**
 	 * Creates a new game factory.
@@ -22,7 +22,7 @@ public class GameFactory {
 	 *            The factory providing the player objects.
 	 */
 	public GameFactory(PlayerFactory playerFactory) {
-		this.playerFact = playerFactory;
+		this.playerFactory = playerFactory;
 	}
 
 	/**
@@ -33,14 +33,15 @@ public class GameFactory {
 	 * @return A new single player game.
 	 */
 	public Game createSinglePlayerGame(Level level) {
-		return new SinglePlayerGame(playerFact.createPacMan(), level);
+		return new SinglePlayerGame(playerFactory.createPacMan(), level);
 	}
 
 	/**
 	 * Returns the player factory associated with this game factory.
-	 * @return the player factory associated with this game factory.
+	 *
+	 * @return The player factory associated with this game factory.
 	 */
 	protected PlayerFactory getPlayerFactory() {
-		return playerFact;
+		return playerFactory;
 	}
 }

--- a/src/main/java/nl/tudelft/jpacman/game/SinglePlayerGame.java
+++ b/src/main/java/nl/tudelft/jpacman/game/SinglePlayerGame.java
@@ -27,18 +27,18 @@ public class SinglePlayerGame extends Game {
 	/**
 	 * Create a new single player game for the provided level and player.
 	 * 
-	 * @param p
+	 * @param player
 	 *            The player.
-	 * @param l
+	 * @param level
 	 *            The level.
 	 */
-	protected SinglePlayerGame(Player p, Level l) {
-		assert p != null;
-		assert l != null;
+	protected SinglePlayerGame(Player player, Level level) {
+		assert player != null;
+		assert level != null;
 
-		this.player = p;
-		this.level = l;
-		level.registerPlayer(p);
+		this.player = player;
+		this.level = level;
+		this.level.registerPlayer(player);
 	}
 
 	@Override

--- a/src/main/java/nl/tudelft/jpacman/level/CollisionInteractionMap.java
+++ b/src/main/java/nl/tudelft/jpacman/level/CollisionInteractionMap.java
@@ -49,8 +49,7 @@ public class CollisionInteractionMap implements CollisionMap {
 	 *            The handler that handles the collision.
 	 */
 	public <C1 extends Unit, C2 extends Unit> void onCollision(
-			Class<C1> collider, Class<C2> collidee,
-			CollisionHandler<C1, C2> handler) {
+			Class<C1> collider, Class<C2> collidee, CollisionHandler<C1, C2> handler) {
 		onCollision(collider, collidee, true, handler);
 	}
 
@@ -78,8 +77,7 @@ public class CollisionInteractionMap implements CollisionMap {
 			CollisionHandler<C1, C2> handler) {
 		addHandler(collider, collidee, handler);
 		if (symetric) {
-			addHandler(collidee, collider, new InverseCollisionHandler<>(
-					handler));
+			addHandler(collidee, collider, new InverseCollisionHandler<>(handler));
 		}
 	}
 
@@ -96,13 +94,10 @@ public class CollisionInteractionMap implements CollisionMap {
 	private void addHandler(Class<? extends Unit> collider,
 			Class<? extends Unit> collidee, CollisionHandler<?, ?> handler) {
 		if (!handlers.containsKey(collider)) {
-			handlers.put(
-					collider,
-					new HashMap<>());
+			handlers.put(collider, new HashMap<>());
 		}
 
-		Map<Class<? extends Unit>, CollisionHandler<?, ?>> map = handlers
-				.get(collider);
+		Map<Class<? extends Unit>, CollisionHandler<?, ?>> map = handlers.get(collider);
 		map.put(collidee, handler);
 	}
 
@@ -124,22 +119,18 @@ public class CollisionInteractionMap implements CollisionMap {
 	@Override
 	public <C1 extends Unit, C2 extends Unit> void collide(C1 collider,
 			C2 collidee) {
-		Class<? extends Unit> colliderKey = getMostSpecificClass(handlers,
-				collider.getClass());
+		Class<? extends Unit> colliderKey = getMostSpecificClass(handlers, collider.getClass());
 		if (colliderKey == null) {
 			return;
 		}
 
-		Map<Class<? extends Unit>, CollisionHandler<?, ?>> map = handlers
-				.get(colliderKey);
-		Class<? extends Unit> collideeKey = getMostSpecificClass(map,
-				collidee.getClass());
+		Map<Class<? extends Unit>, CollisionHandler<?, ?>> map = handlers.get(colliderKey);
+		Class<? extends Unit> collideeKey = getMostSpecificClass(map, collidee.getClass());
 		if (collideeKey == null) {
 			return;
 		}
 
-		CollisionHandler<C1, C2> collisionHandler = (CollisionHandler<C1, C2>) map
-				.get(collideeKey);
+		CollisionHandler<C1, C2> collisionHandler = (CollisionHandler<C1, C2>) map.get(collideeKey);
 		if (collisionHandler == null) {
 			return;
 		}

--- a/src/main/java/nl/tudelft/jpacman/level/LevelFactory.java
+++ b/src/main/java/nl/tudelft/jpacman/level/LevelFactory.java
@@ -90,16 +90,16 @@ public class LevelFactory {
 		ghostIndex++;
 		ghostIndex %= GHOSTS;
 		switch (ghostIndex) {
-		case BLINKY:
-			return ghostFact.createBlinky();
-		case INKY:
-			return ghostFact.createInky();
-		case PINKY:
-			return ghostFact.createPinky();
-		case CLYDE:
-			return ghostFact.createClyde();
-		default:
-			return new RandomGhost(sprites.getGhostSprite(GhostColor.RED));
+			case BLINKY:
+				return ghostFact.createBlinky();
+			case INKY:
+				return ghostFact.createInky();
+			case PINKY:
+				return ghostFact.createPinky();
+			case CLYDE:
+				return ghostFact.createClyde();
+			default:
+				return new RandomGhost(sprites.getGhostSprite(GhostColor.RED));
 		}
 	}
 

--- a/src/main/java/nl/tudelft/jpacman/level/PlayerCollisions.java
+++ b/src/main/java/nl/tudelft/jpacman/level/PlayerCollisions.java
@@ -18,7 +18,6 @@ public class PlayerCollisions implements CollisionMap {
 
 	@Override
 	public void collide(Unit mover, Unit collidedOn) {
-		
 		if (mover instanceof Player) {
 			playerColliding((Player) mover, collidedOn);
 		}
@@ -34,7 +33,6 @@ public class PlayerCollisions implements CollisionMap {
 		if (collidedOn instanceof Ghost) {
 			playerVersusGhost(player, (Ghost) collidedOn);
 		}
-		
 		if (collidedOn instanceof Pellet) {
 			playerVersusPellet(player, (Pellet) collidedOn);
 		}		

--- a/src/main/java/nl/tudelft/jpacman/level/PlayerFactory.java
+++ b/src/main/java/nl/tudelft/jpacman/level/PlayerFactory.java
@@ -30,8 +30,7 @@ public class PlayerFactory {
 	 * @return A new player.
 	 */
 	public Player createPacMan() {
-		return new Player(getSprites().getPacmanSprites(),
-				getSprites().getPacManDeathAnimation());
+		return new Player(getSprites().getPacmanSprites(), getSprites().getPacManDeathAnimation());
 	}
 
 	/**

--- a/src/main/java/nl/tudelft/jpacman/npc/ghost/Blinky.java
+++ b/src/main/java/nl/tudelft/jpacman/npc/ghost/Blinky.java
@@ -90,8 +90,7 @@ public class Blinky extends Ghost {
 		assert nearest.hasSquare();
 		Square target = nearest.getSquare();
 
-		List<Direction> path = Navigation.shortestPath(getSquare(), target,
-				this);
+		List<Direction> path = Navigation.shortestPath(getSquare(), target, this);
 		if (path != null && !path.isEmpty()) {
 			return path.get(0);
 		}

--- a/src/main/java/nl/tudelft/jpacman/npc/ghost/Clyde.java
+++ b/src/main/java/nl/tudelft/jpacman/npc/ghost/Clyde.java
@@ -61,8 +61,7 @@ public class Clyde extends Ghost {
 	/**
 	 * A map of opposite directions.
 	 */
-	private static final Map<Direction, Direction> OPPOSITES = new EnumMap<>(
-			Direction.class);
+	private static final Map<Direction, Direction> OPPOSITES = new EnumMap<>(Direction.class);
 	static {
 		OPPOSITES.put(Direction.NORTH, Direction.SOUTH);
 		OPPOSITES.put(Direction.SOUTH, Direction.NORTH);
@@ -108,14 +107,13 @@ public class Clyde extends Ghost {
 		assert nearest.hasSquare();
 		Square target = nearest.getSquare();
 
-		List<Direction> path = Navigation.shortestPath(getSquare(), target,
-				this);
+		List<Direction> path = Navigation.shortestPath(getSquare(), target, this);
 		if (path != null && !path.isEmpty()) {
-			Direction d = path.get(0);
+			Direction direction = path.get(0);
 			if (path.size() <= SHYNESS) {
-				return OPPOSITES.get(d);
+				return OPPOSITES.get(direction);
 			}
-			return d;
+			return direction;
 		}
 		return randomMove();
 	}

--- a/src/main/java/nl/tudelft/jpacman/npc/ghost/Ghost.java
+++ b/src/main/java/nl/tudelft/jpacman/npc/ghost/Ghost.java
@@ -68,9 +68,9 @@ public abstract class Ghost extends NPC {
 	@Nullable protected Direction randomMove() {
 		Square square = getSquare();
 		List<Direction> directions = new ArrayList<>();
-		for (Direction d : Direction.values()) {
-			if (square.getSquareAt(d).isAccessibleTo(this)) {
-				directions.add(d);
+		for (Direction direction : Direction.values()) {
+			if (square.getSquareAt(direction).isAccessibleTo(this)) {
+				directions.add(direction);
 			}
 		}
 		if (directions.isEmpty()) {

--- a/src/main/java/nl/tudelft/jpacman/npc/ghost/Navigation.java
+++ b/src/main/java/nl/tudelft/jpacman/npc/ghost/Navigation.java
@@ -40,7 +40,7 @@ public final class Navigation {
 	 *         square, an empty list is returned.
 	 */
 	public @Nullable static List<Direction> shortestPath(Square from, Square to,
-			@Nullable  Unit traveller) {
+			@Nullable Unit traveller) {
 		if (from.equals(to)) {
 			return new ArrayList<>();
 		}
@@ -49,25 +49,24 @@ public final class Navigation {
 		Set<Square> visited = new HashSet<>();
 		targets.add(new Node(null, from, null));
 		while (!targets.isEmpty()) {
-			Node n = targets.remove(0);
-			Square s = n.getSquare();
-			if (s.equals(to)) {
-				return n.getPath();
+			Node node = targets.remove(0);
+			Square square = node.getSquare();
+			if (square.equals(to)) {
+				return node.getPath();
 			}
-			visited.add(s);
-			addNewTargets(traveller, targets, visited, n, s);
+			visited.add(square);
+			addNewTargets(traveller, targets, visited, node, square);
 		}
 		return null;
 	}
 
 	private static void addNewTargets(@Nullable Unit traveller, List<Node> targets,
-			Set<Square> visited, Node n, Square s) {
-		for (Direction d : Direction.values()) {
-			Square target = s.getSquareAt(d);
+			Set<Square> visited, Node node, Square square) {
+		for (Direction direction : Direction.values()) {
+			Square target = square.getSquareAt(direction);
 			if (!visited.contains(target)
-					&& (traveller == null || target
-							.isAccessibleTo(traveller))) {
-				targets.add(new Node(d, target, n));
+					&& (traveller == null || target.isAccessibleTo(traveller))) {
+				targets.add(new Node(direction, target, node));
 			}
 		}
 	}
@@ -99,8 +98,8 @@ public final class Navigation {
 				return unit;
 			}
 			visited.add(square);
-			for (Direction d : Direction.values()) {
-				Square newTarget = square.getSquareAt(d);
+			for (Direction direction : Direction.values()) {
+				Square newTarget = square.getSquareAt(direction);
 				if (!visited.contains(newTarget) && !toDo.contains(newTarget)) {
 					toDo.add(newTarget);
 				}
@@ -120,10 +119,10 @@ public final class Navigation {
 	 *         <code>null</code> of none does.
 	 */
 	public @Nullable static Unit findUnit(Class<? extends Unit> type, Square square) {
-		for (Unit u : square.getOccupants()) {
-			if (type.isInstance(u)) {
-				assert u.hasSquare();
-				return u;
+		for (Unit unit : square.getOccupants()) {
+			if (type.isInstance(unit)) {
+				assert unit.hasSquare();
+				return unit;
 			}
 		}
 		return null;
@@ -155,19 +154,19 @@ public final class Navigation {
 		/**
 		 * Creates a new node.
 		 * 
-		 * @param d
+		 * @param direction
 		 *            The direction, which is <code>null</code> for the root
 		 *            node.
-		 * @param s
+		 * @param square
 		 *            The square.
-		 * @param p
+		 * @param parent
 		 *            The parent node, which is <code>null</code> for the root
 		 *            node.
 		 */
-		Node(@Nullable Direction d, Square s, @Nullable Node p) {
-			this.direction = d;
-			this.square = s;
-			this.parent = p;
+		Node(@Nullable Direction direction, Square square, @Nullable Node parent) {
+			this.direction = direction;
+			this.square = square;
+			this.parent = parent;
 		}
 
 		/**

--- a/src/main/java/nl/tudelft/jpacman/npc/ghost/Pinky.java
+++ b/src/main/java/nl/tudelft/jpacman/npc/ghost/Pinky.java
@@ -102,8 +102,7 @@ public class Pinky extends Ghost {
 			destination = destination.getSquareAt(targetDirection);
 		}
 
-		List<Direction> path = Navigation.shortestPath(getSquare(),
-				destination, this);
+		List<Direction> path = Navigation.shortestPath(getSquare(), destination, this);
 		if (path != null && !path.isEmpty()) {
 			return path.get(0);
 		}

--- a/src/main/java/nl/tudelft/jpacman/sprite/AnimatedSprite.java
+++ b/src/main/java/nl/tudelft/jpacman/sprite/AnimatedSprite.java
@@ -72,8 +72,7 @@ public class AnimatedSprite implements Sprite {
 	 * @param isAnimating
 	 *            Whether or not this sprite is animating from the start.
 	 */
-	public AnimatedSprite(Sprite[] frames, int delay, boolean loop,
-			boolean isAnimating) {
+	public AnimatedSprite(Sprite[] frames, int delay, boolean loop, boolean isAnimating) {
 		assert frames.length > 0;
 
 		this.animationFrames = frames.clone();
@@ -118,9 +117,9 @@ public class AnimatedSprite implements Sprite {
 	}
 
 	@Override
-	public void draw(Graphics g, int x, int y, int width, int height) {
+	public void draw(Graphics graphics, int x, int y, int width, int height) {
 		update();
-		currentSprite().draw(g, x, y, width, height);
+		currentSprite().draw(graphics, x, y, width, height);
 	}
 
 	@Override

--- a/src/main/java/nl/tudelft/jpacman/sprite/EmptySprite.java
+++ b/src/main/java/nl/tudelft/jpacman/sprite/EmptySprite.java
@@ -11,7 +11,7 @@ import java.awt.Graphics;
 public class EmptySprite implements Sprite {
 
 	@Override
-	public void draw(Graphics g, int x, int y, int width, int height) {
+	public void draw(Graphics graphics, int x, int y, int width, int height) {
 		// nothing to draw.
 	}
 

--- a/src/main/java/nl/tudelft/jpacman/sprite/ImageSprite.java
+++ b/src/main/java/nl/tudelft/jpacman/sprite/ImageSprite.java
@@ -30,8 +30,8 @@ public class ImageSprite implements Sprite {
 	}
 
 	@Override
-	public void draw(Graphics g, int x, int y, int width, int height) {
-		g.drawImage(image, x, y, x + width, y + height, 0, 0,
+	public void draw(Graphics graphics, int x, int y, int width, int height) {
+		graphics.drawImage(image, x, y, x + width, y + height, 0, 0,
 				image.getWidth(null), image.getHeight(null), null);
 	}
 

--- a/src/main/java/nl/tudelft/jpacman/sprite/PacManSprites.java
+++ b/src/main/java/nl/tudelft/jpacman/sprite/PacManSprites.java
@@ -19,8 +19,12 @@ public class PacManSprites extends SpriteStore {
 	 * The sprite files are vertically stacked series for each direction, this
 	 * array denotes the order.
 	 */
-	private static final Direction[] DIRECTIONS = { Direction.NORTH,
-			Direction.EAST, Direction.SOUTH, Direction.WEST };
+	private static final Direction[] DIRECTIONS = {
+			Direction.NORTH,
+			Direction.EAST,
+			Direction.SOUTH,
+			Direction.WEST
+	};
 
 	/**
 	 * The image size in pixels.

--- a/src/main/java/nl/tudelft/jpacman/sprite/Sprite.java
+++ b/src/main/java/nl/tudelft/jpacman/sprite/Sprite.java
@@ -12,7 +12,7 @@ public interface Sprite {
 	/**
 	 * Draws the sprite on the provided graphics context.
 	 * 
-	 * @param g
+	 * @param graphics
 	 *            The graphics context to draw.
 	 * @param x
 	 *            The destination x coordinate to start drawing.
@@ -23,7 +23,7 @@ public interface Sprite {
 	 * @param height
 	 *            The height of the destination draw area.
 	 */
-	void draw(Graphics g, int x, int y, int width, int height);
+	void draw(Graphics graphics, int x, int y, int width, int height);
 
 	/**
 	 * Returns a portion of this sprite as a new Sprite.

--- a/src/main/java/nl/tudelft/jpacman/sprite/SpriteStore.java
+++ b/src/main/java/nl/tudelft/jpacman/sprite/SpriteStore.java
@@ -60,8 +60,7 @@ public class SpriteStore {
 	private Sprite loadSpriteFromResource(String resource) throws IOException {
 		try (InputStream input = SpriteStore.class.getResourceAsStream(resource)) {
 			if (input == null) {
-				throw new IOException("Unable to load " + resource
-					+ ", resource does not exist.");
+				throw new IOException("Unable to load " + resource + ", resource does not exist.");
 			}
 			BufferedImage image = ImageIO.read(input);
 			return new ImageSprite(image);

--- a/src/main/java/nl/tudelft/jpacman/ui/BoardPanel.java
+++ b/src/main/java/nl/tudelft/jpacman/ui/BoardPanel.java
@@ -72,24 +72,24 @@ class BoardPanel extends JPanel {
 	 * 
 	 * @param board
 	 *            The board to render.
-	 * @param g
+	 * @param graphics
 	 *            The graphics context to draw on.
 	 * @param window
 	 *            The dimensions to scale the rendered board to.
 	 */
-	private void render(Board board, Graphics g, Dimension window) {
+	private void render(Board board, Graphics graphics, Dimension window) {
 		int cellW = window.width / board.getWidth();
 		int cellH = window.height / board.getHeight();
 
-		g.setColor(BACKGROUND_COLOR);
-		g.fillRect(0, 0, window.width, window.height);
+		graphics.setColor(BACKGROUND_COLOR);
+		graphics.fillRect(0, 0, window.width, window.height);
 
 		for (int y = 0; y < board.getHeight(); y++) {
 			for (int x = 0; x < board.getWidth(); x++) {
 				int cellX = x * cellW;
 				int cellY = y * cellH;
 				Square square = board.squareAt(x, y);
-				render(square, g, cellX, cellY, cellW, cellH);
+				render(square, graphics, cellX, cellY, cellW, cellH);
 			}
 		}
 	}
@@ -100,21 +100,21 @@ class BoardPanel extends JPanel {
 	 * 
 	 * @param square
 	 *            The square to render.
-	 * @param g
+	 * @param graphics
 	 *            The graphics context to draw on.
 	 * @param x
 	 *            The x position to start drawing.
 	 * @param y
 	 *            The y position to start drawing.
-	 * @param w
+	 * @param width
 	 *            The width of this square (in pixels.)
-	 * @param h
+	 * @param height
 	 *            The height of this square (in pixels.)
 	 */
-	private void render(Square square, Graphics g, int x, int y, int w, int h) {
-		square.getSprite().draw(g, x, y, w, h);
+	private void render(Square square, Graphics graphics, int x, int y, int width, int height) {
+		square.getSprite().draw(graphics, x, y, width, height);
 		for (Unit unit : square.getOccupants()) {
-			unit.getSprite().draw(g, x, y, w, h);
+			unit.getSprite().draw(graphics, x, y, width, height);
 		}
 	}
 }

--- a/src/main/java/nl/tudelft/jpacman/ui/PacKeyListener.java
+++ b/src/main/java/nl/tudelft/jpacman/ui/PacKeyListener.java
@@ -26,21 +26,21 @@ class PacKeyListener implements KeyListener {
 	}
 	
 	@Override
-	public void keyPressed(KeyEvent e) {
-		assert e != null;
-		Action action = mappings.get(e.getKeyCode());
+	public void keyPressed(KeyEvent event) {
+		assert event != null;
+		Action action = mappings.get(event.getKeyCode());
 		if (action != null) {
 			action.doAction();
 		}
 	}
 
 	@Override
-	public void keyTyped(KeyEvent e) {
+	public void keyTyped(KeyEvent event) {
 		// do nothing
 	}
 	
 	@Override
-	public void keyReleased(KeyEvent e) {
+	public void keyReleased(KeyEvent event) {
 		// do nothing
 	}
 }

--- a/src/main/java/nl/tudelft/jpacman/ui/PacManUI.java
+++ b/src/main/java/nl/tudelft/jpacman/ui/PacManUI.java
@@ -63,12 +63,12 @@ public class PacManUI extends JFrame {
 	 * @param keyMappings
 	 *            The map of keyCode-to-action entries that will be added as key
 	 *            listeners to the interface.
-	 * @param sf
+	 * @param scoreFormatter
 	 *            The formatter used to display the current score. 
 	 */
 	@SuppressWarnings("initialization") // requestFocusInWindow called before initialization ends
 	public PacManUI(final Game game, final Map<String, Action> buttons,
-			final Map<Integer, Action> keyMappings, @Nullable ScoreFormatter sf) {
+			final Map<Integer, Action> keyMappings, @Nullable ScoreFormatter scoreFormatter) {
 		super("JPac-Man");
 		assert game != null;
 		assert buttons != null;
@@ -82,8 +82,8 @@ public class PacManUI extends JFrame {
 		JPanel buttonPanel = new ButtonPanel(buttons, this);
 
 		scorePanel = new ScorePanel(game.getPlayers());
-		if (sf != null) {
-			scorePanel.setScoreFormatter(sf);
+		if (scoreFormatter != null) {
+			scorePanel.setScoreFormatter(scoreFormatter);
 		}
 		
 		boardPanel = new BoardPanel(game);

--- a/src/main/java/nl/tudelft/jpacman/ui/PacManUiBuilder.java
+++ b/src/main/java/nl/tudelft/jpacman/ui/PacManUiBuilder.java
@@ -148,13 +148,13 @@ public class PacManUiBuilder {
 	/**
 	 * Provide formatter for the score.
 	 * 
-	 * @param sf
+	 * @param scoreFormatter
 	 *         The score formatter to be used.
 	 * 
 	 * @return The builder.
 	 */
-	public PacManUiBuilder withScoreFormatter(ScoreFormatter sf) {
-		scoreFormatter = sf;
+	public PacManUiBuilder withScoreFormatter(ScoreFormatter scoreFormatter) {
+		this.scoreFormatter = scoreFormatter;
 		return this;
 	}
 }

--- a/src/main/java/nl/tudelft/jpacman/ui/ScorePanel.java
+++ b/src/main/java/nl/tudelft/jpacman/ui/ScorePanel.java
@@ -56,9 +56,9 @@ public class ScorePanel extends JPanel {
 			add(new JLabel("Player " + i, JLabel.CENTER));
 		}
 		scoreLabels = new LinkedHashMap<>();
-		for (Player p : players) {
+		for (Player player : players) {
 			JLabel scoreLabel = new JLabel("0", JLabel.CENTER);
-			scoreLabels.put(p, scoreLabel);
+			scoreLabels.put(player, scoreLabel);
 			add(scoreLabel);
 		}
 	}
@@ -68,12 +68,12 @@ public class ScorePanel extends JPanel {
 	 */
 	protected void refresh() {
 		for (Map.Entry<Player, JLabel> entry : scoreLabels.entrySet()) {
-			Player p = entry.getKey();
+			Player player = entry.getKey();
 			String score = "";
-			if (!p.isAlive()) {
+			if (!player.isAlive()) {
 				score = "You died. ";
 			}
-			score += scoreFormatter.format(p);
+			score += scoreFormatter.format(player);
 			entry.getValue().setText(score);
 		}
 	}
@@ -85,18 +85,18 @@ public class ScorePanel extends JPanel {
 		
 		/**
 		 * Format the score of a given player.
-		 * @param p The player and its score
+		 * @param player The player and its score
 		 * @return Formatted score.
 		 */
-		String format(Player p);
+		String format(Player player);
 	}
 	
 	/**
 	 * Let the score panel use a dedicated score formatter.
-	 * @param sf Score formatter to be used.
+	 * @param scoreFormatter Score formatter to be used.
 	 */
-	public void setScoreFormatter(ScoreFormatter sf) {
-		assert sf != null;
-		scoreFormatter = sf;
+	public void setScoreFormatter(ScoreFormatter scoreFormatter) {
+		assert scoreFormatter != null;
+		this.scoreFormatter = scoreFormatter;
 	}
 }


### PR DESCRIPTION
This PR contains some small style fixes. For some of the fixes, a relatively large amount of lines is touched (making this PR a bit larger than ideal), but the changes itself are very minor.

* Remove unnecessary abbreviations to improve readability and consistency throughout the code base (in some places there are many, in others none). They make the code harder to read and do not provide any benefit. I hope I caught all of them. (2d15bdc and 9336290)
* Remove (some) unnecessary line breaks for lines short than 100 characters (2d15bdc)
* Remove an unnecessary else case in the launcher. This is done to express the intent of the method better and make it consistent with other code. (9d0a4d4)
* Improve readability of directions in `PacManSprites` by moving them to separate lines (a9f5f65)
* Remove unnecessary empty lines from `PlayerCollisions` (3a05155)
* Fix indentation of the switch statement in the `createGhost` method in `LevelFactory` (9336290)

