### PR TITLE
Update to jdk9 and latest dependency versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,5 @@ before_install:
   - "sh -e /etc/init.d/xvfb start"
 jdk:
   - oraclejdk8
+  - oraclejdk9
 script: "mvn clean test"

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -13,7 +13,6 @@
   <module name="TreeWalker">
     <module name="SuppressWarningsHolder" />
     <property name="tabWidth" value="4"/>
-    <module name="FileContentsHolder"/>
     <module name="JavadocMethod">
       <property name="scope" value="package"/>
       <property name="suppressLoadErrors" value="true"/>
@@ -130,7 +129,5 @@
     <property name="message" value="Line has trailing spaces."/>
     <metadata name="net.sf.eclipsecs.core.lastEnabledSeverity" value="inherit"/>
   </module>
-  <module name="SuppressionCommentFilter"/>
-  <module name="SuppressWithNearbyCommentFilter"/>
   <module name="SuppressWarningsFilter" />
 </module>

--- a/pmd-rules.xml
+++ b/pmd-rules.xml
@@ -8,6 +8,8 @@
         Custom rules for checking JUnit test quality.
     </description>
 
+
+<!--
     <rule ref="rulesets/java/basic.xml"/>
     <rule ref="rulesets/java/unusedcode.xml"/>
     <rule ref="rulesets/java/imports.xml"/>
@@ -16,12 +18,19 @@
     <rule ref="rulesets/java/braces.xml"/>
     <rule ref="rulesets/java/clone.xml"/>
     <rule ref="rulesets/java/empty.xml"/>
-    <rule ref="rulesets/java/junit.xml">
-        <exclude name="JUnitAssertionsShouldIncludeMessage"/>
-	    <exclude name="JUnitTestContainsTooManyAsserts"/>
+    <rule ref="category/java/errorprone.xml">
         <exclude name="TestClassWithoutTestCases"/>
     </rule>
-    <rule ref="rulesets/java/junit.xml/JUnitTestContainsTooManyAsserts">
+-->
+    <rule ref="category/java/bestpractices.xml">
+        <exclude name="JUnitAssertionsShouldIncludeMessage"/>
+	    <exclude name="JUnitTestContainsTooManyAsserts"/>
+        <exclude name="JUnit4TestShouldUseAfterAnnotation" />
+        <exclude name="JUnit4TestShouldUseBeforeAnnotation" />
+        <exclude name="UseVarargs" />
+        <exclude name="AccessorMethodGeneration" />
+    </rule>
+    <rule ref="category/java/bestpractices.xml/JUnitTestContainsTooManyAsserts">
         <properties>
             <property name="maximumAsserts" value="5" />
         </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -34,10 +34,6 @@
 
 	<modelVersion>4.0.0</modelVersion>
 
-	<prerequisites>
-		<maven>3.0.1</maven>
-	</prerequisites>
-
 	<properties>
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,81 @@
 
 	<modelVersion>4.0.0</modelVersion>
 
+	<profiles>
+		<profile>
+			<id>java9</id>
+			<activation>
+				<jdk>9.0</jdk>
+			</activation>
+			<properties>
+				<maven.compiler.source>1.9</maven.compiler.source>
+				<maven.compiler.target>1.9</maven.compiler.target>
+			</properties>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-surefire-plugin</artifactId>
+						<version>${surefire.plugin.version}</version>
+						<configuration>
+							<trimStackTrace>false</trimStackTrace>
+	                        <argLine>
+	                            --add-opens java.base/java.util=ALL-UNNAMED
+                                --add-opens java.base/java.lang.reflect=ALL-UNNAMED
+                                --add-opens java.base/java.text=ALL-UNNAMED
+                                --add-opens java.desktop/java.awt.font=ALL-UNNAMED
+                            </argLine>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+
+		<profile>
+			<id>java8</id>
+			<activation>
+				<jdk>1.8</jdk>
+			</activation>
+			<properties>
+				<maven.compiler.source>1.8</maven.compiler.source>
+				<maven.compiler.target>1.8</maven.compiler.target>
+				<!-- IntelliJ will warn about this line, but the maven-dependency-plugin
+		             does correctly resolve this, so there is nothing to worry about. -->
+				<annotatedJdk>${org.checkerframework:jdk8:jar}</annotatedJdk>
+			</properties>
+			<dependencies>
+				<!-- The annotated JDK to use (change to jdk7 if using Java 7). -->
+				<dependency>
+					<groupId>org.checkerframework</groupId>
+					<artifactId>jdk8</artifactId>
+					<version>${checkerframework.plugin.version}</version>
+				</dependency>
+			</dependencies>
+			<build>
+				<plugins>
+					<plugin>
+						<artifactId>maven-compiler-plugin</artifactId>
+						<version>${compiler.plugin.version}</version>
+						<configuration>
+							<source>${maven.compiler.source}</source>
+							<target>${maven.compiler.target}</target>
+							<fork>true</fork>
+							<annotationProcessors>
+								<annotationProcessor>org.checkerframework.checker.nullness.NullnessChecker</annotationProcessor>
+							</annotationProcessors>
+							<compilerArgs>
+								<arg>-Xbootclasspath/p:${annotatedJdk}</arg>
+								<arg>-AskipUses=^java</arg>
+								<arg>-AskipDefs=Test$|e2e</arg>
+								<arg>-AassumeAssertionsAreEnabled</arg>
+							</compilerArgs>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
+
 	<properties>
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>
@@ -52,6 +127,7 @@
         <mockito.version>2.16.0</mockito.version>
 
         <assembly.plugin.version>3.1.0</assembly.plugin.version>
+		<checkerframework.plugin.version>2.4.0</checkerframework.plugin.version>
 		<checkstyle.plugin.version>3.0.0</checkstyle.plugin.version>
 		<checkstyle.version>8.8</checkstyle.version>
 		<compiler.plugin.version>3.7.0</compiler.plugin.version>
@@ -67,10 +143,6 @@
 		<shade.plugin.version>3.1.0</shade.plugin.version>
 		<surefire.plugin.version>2.19.1</surefire.plugin.version>
 
-		<checkerframework.plugin.version>2.4.0</checkerframework.plugin.version>
-		<!-- IntelliJ will warn about this line, but the maven-dependency-plugin
-		     does correctly resolve this, so there is nothing to worry about. -->
-		<annotatedJdk>${org.checkerframework:jdk8:jar}</annotatedJdk>
 	</properties>
 
 	<dependencies>
@@ -158,13 +230,6 @@
 			<artifactId>checker</artifactId>
 			<version>${checkerframework.plugin.version}</version>
 		</dependency>
-		<!-- The annotated JDK to use (change to jdk7 if using Java 7). -->
-		<dependency>
-			<groupId>org.checkerframework</groupId>
-			<artifactId>jdk8</artifactId>
-			<version>${checkerframework.plugin.version}</version>
-		</dependency>
-
 	</dependencies>
 
 	<build>
@@ -189,16 +254,6 @@
 				<configuration>
 					<source>${maven.compiler.source}</source>
 					<target>${maven.compiler.target}</target>
-					<fork>true</fork>
-					<annotationProcessors>
-						<annotationProcessor>org.checkerframework.checker.nullness.NullnessChecker</annotationProcessor>
-					</annotationProcessors>
-					<compilerArgs>
-						<arg>-Xbootclasspath/p:${annotatedJdk}</arg>
-						<arg>-AskipUses=^java</arg>
-						<arg>-AskipDefs=Test$|e2e</arg>
-						<arg>-AassumeAssertionsAreEnabled</arg>
-					</compilerArgs>
 				</configuration>
 			</plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -116,23 +116,23 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <junit.jupiter.version>5.1.0</junit.jupiter.version>
-        <junit.platform.version>1.1.0</junit.platform.version>
+        <junit.jupiter.version>5.1.1</junit.jupiter.version>
+        <junit.platform.version>1.1.1</junit.platform.version>
 
         <junit.version>4.12</junit.version>
         <junit.vintage.version>5.1.0</junit.vintage.version>
 
         <cucumber.version>1.2.5</cucumber.version>
         <assertj.version>3.9.1</assertj.version>
-        <mockito.version>2.16.0</mockito.version>
+        <mockito.version>2.18.0</mockito.version>
 
         <assembly.plugin.version>3.1.0</assembly.plugin.version>
-		<checkerframework.plugin.version>2.4.0</checkerframework.plugin.version>
+		<checkerframework.plugin.version>2.5.0</checkerframework.plugin.version>
 		<checkstyle.plugin.version>3.0.0</checkstyle.plugin.version>
-		<checkstyle.version>8.8</checkstyle.version>
+		<checkstyle.version>8.9</checkstyle.version>
 		<compiler.plugin.version>3.7.0</compiler.plugin.version>
 		<dependency.plugin.version>3.0.2</dependency.plugin.version>
-		<spotbugs.plugin.version>3.1.0</spotbugs.plugin.version>
+		<spotbugs.plugin.version>3.1.3</spotbugs.plugin.version>
 		<guava.plugin.version>24.1-jre</guava.plugin.version>
 		<jacoco.plugin.version>0.8.1</jacoco.plugin.version>
 		<jar.plugin.version>3.0.2</jar.plugin.version>
@@ -234,6 +234,28 @@
 
 	<build>
 		<plugins>
+
+		    <plugin>
+		        <groupId>org.apache.maven.plugins</groupId>
+		        <artifactId>maven-enforcer-plugin</artifactId>
+		        <version>3.0.0-M1</version>
+		        <executions>
+		            <execution>
+		                <id>enforce-maven</id>
+			            <goals>
+   			                <goal>enforce</goal>
+			            </goals>
+			            <configuration>
+			                <rules>
+			                    <requireMavenVersion>
+			                        <version>3.1.1</version>
+			                    </requireMavenVersion>
+			                </rules>    
+			            </configuration>
+		            </execution>
+		        </executions>
+		    </plugin>
+
 			<plugin>
 				<!-- This plugin will set properties values using dependency information -->
 				<groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -325,6 +325,8 @@
 				<artifactId>maven-pmd-plugin</artifactId>
 				<version>${pmd.plugin.version}</version>
 				<configuration>
+					<!-- not yet ready for jdk 1.9 -->
+					<targetJdk>1.8</targetJdk>
 					<skipEmptyReport>false</skipEmptyReport>
 					<includeTests>true</includeTests>
 					<rulesets>
@@ -498,6 +500,9 @@
 				<artifactId>maven-pmd-plugin</artifactId>
 				<version>${pmd.plugin.version}</version>
 				<configuration>
+					<!-- not yet ready for jdk 1.9 -->
+					<targetJdk>1.8</targetJdk>
+					<analysisCache>true</analysisCache>
 					<skipEmptyReport>false</skipEmptyReport>
 					<includeTests>true</includeTests>
 					<rulesets>

--- a/pom.xml
+++ b/pom.xml
@@ -327,6 +327,7 @@
 				<configuration>
 					<!-- not yet ready for jdk 1.9 -->
 					<targetJdk>1.8</targetJdk>
+					<analysisCache>true</analysisCache>
 					<skipEmptyReport>false</skipEmptyReport>
 					<includeTests>true</includeTests>
 					<rulesets>

--- a/pom.xml
+++ b/pom.xml
@@ -303,19 +303,15 @@
 				<artifactId>maven-jar-plugin</artifactId>
 				<version>${jar.plugin.version}</version>
 				<configuration>
-					<useDefaultManifestFile>true</useDefaultManifestFile>
+                    <archive>
+                        <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                    </archive>
 				</configuration>
 				<executions>
 					<execution>
 						<id>test-files</id>
 						<goals>
 							<goal>test-jar</goal>
-						</goals>
-					</execution>
-					<execution>
-						<id>src-files</id>
-						<goals>
-							<goal>jar</goal>
 						</goals>
 					</execution>
 				</executions>

--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,7 @@
 		<checkstyle.version>8.8</checkstyle.version>
 		<compiler.plugin.version>3.7.0</compiler.plugin.version>
 		<dependency.plugin.version>3.0.2</dependency.plugin.version>
-		<findbugs.plugin.version>3.0.5</findbugs.plugin.version>
+		<spotbugs.plugin.version>3.1.0</spotbugs.plugin.version>
 		<guava.plugin.version>24.1-jre</guava.plugin.version>
 		<jacoco.plugin.version>0.8.1</jacoco.plugin.version>
 		<jar.plugin.version>3.0.2</jar.plugin.version>
@@ -299,7 +299,7 @@
 				</executions>
 			</plugin>
 
-			<!-- The checkstyle, findbugs and PMD plugins have configurations, for
+			<!-- The checkstyle, spotbugs and PMD plugins have configurations, for
 				the checkstyle:checkstyle and pmd:pmd to work properly, the plugins should
 				also be specified under the build section. See: https://github.com/sevntu-checkstyle/checkstyle-samples/blob/master/maven-project/pom.xml -->
 
@@ -337,14 +337,16 @@
 			</plugin>
 
 			<plugin>
-				<groupId>org.codehaus.mojo</groupId>
-				<artifactId>findbugs-maven-plugin</artifactId>
-				<version>${findbugs.plugin.version}</version>
+                <groupId>com.github.spotbugs</groupId>
+                <artifactId>spotbugs-maven-plugin</artifactId>
+                <version>${spotbugs.plugin.version}</version>
 				<configuration>
 					<xmlOutput>true</xmlOutput>
 					<includeTests>true</includeTests>
+					<onlyAnalyze>nl.tudelft.jpacman.*</onlyAnalyze>
 				</configuration>
 			</plugin>
+
 
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
@@ -491,9 +493,9 @@
 			</plugin>
 
 			<plugin>
-				<groupId>org.codehaus.mojo</groupId>
-				<artifactId>findbugs-maven-plugin</artifactId>
-				<version>${findbugs.plugin.version}</version>
+		        <groupId>com.github.spotbugs</groupId>
+		        <artifactId>spotbugs-maven-plugin</artifactId>
+		        <version>3.1.0</version>
 			</plugin>
 
 			<plugin>
@@ -513,12 +515,13 @@
 			</plugin>
 
 			<plugin>
-				<groupId>org.codehaus.mojo</groupId>
-				<artifactId>findbugs-maven-plugin</artifactId>
-				<version>${findbugs.plugin.version}</version>
-				<configuration>
+                <groupId>com.github.spotbugs</groupId>
+                <artifactId>spotbugs-maven-plugin</artifactId>
+                <version>${spotbugs.plugin.version}</version>
+                <configuration>
 					<xmlOutput>true</xmlOutput>
 					<includeTests>true</includeTests>
+					<onlyAnalyze>nl.tudelft.jpacman.*</onlyAnalyze>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -45,33 +45,33 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <junit.jupiter.version>5.0.0-M4</junit.jupiter.version>
-        <junit.platform.version>1.0.0-M4</junit.platform.version>
+        <junit.jupiter.version>5.1.0</junit.jupiter.version>
+        <junit.platform.version>1.1.0</junit.platform.version>
 
         <junit.version>4.12</junit.version>
-        <junit.vintage.version>${junit.version}.0-M4</junit.vintage.version>
+        <junit.vintage.version>5.1.0</junit.vintage.version>
 
         <cucumber.version>1.2.5</cucumber.version>
-        <assertj.version>3.6.2</assertj.version>
-        <mockito.version>2.7.19</mockito.version>
+        <assertj.version>3.9.1</assertj.version>
+        <mockito.version>2.16.0</mockito.version>
 
-        <assembly.plugin.version>2.6</assembly.plugin.version>
-		<checkstyle.plugin.version>2.17</checkstyle.plugin.version>
-		<checkstyle.version>7.6.1</checkstyle.version>
-		<compiler.plugin.version>3.6.1</compiler.plugin.version>
-		<dependency.plugin.version>2.3</dependency.plugin.version>
-		<findbugs.plugin.version>3.0.3</findbugs.plugin.version>
-		<guava.plugin.version>21.0</guava.plugin.version>
-		<jacoco.plugin.version>0.7.6.201602180812</jacoco.plugin.version>
-		<jar.plugin.version>2.6</jar.plugin.version>
+        <assembly.plugin.version>3.1.0</assembly.plugin.version>
+		<checkstyle.plugin.version>3.0.0</checkstyle.plugin.version>
+		<checkstyle.version>8.8</checkstyle.version>
+		<compiler.plugin.version>3.7.0</compiler.plugin.version>
+		<dependency.plugin.version>3.0.2</dependency.plugin.version>
+		<findbugs.plugin.version>3.0.5</findbugs.plugin.version>
+		<guava.plugin.version>24.1-jre</guava.plugin.version>
+		<jacoco.plugin.version>0.8.1</jacoco.plugin.version>
+		<jar.plugin.version>3.0.2</jar.plugin.version>
 		<jxr.plugin.version>2.5</jxr.plugin.version>
-		<javadoc.plugin.version>2.10.3</javadoc.plugin.version>
+		<javadoc.plugin.version>3.0.0</javadoc.plugin.version>
 		<projectinfo.plugin.version>2.9</projectinfo.plugin.version>
-		<pmd.plugin.version>3.6</pmd.plugin.version>
-		<shade.plugin.version>2.4.3</shade.plugin.version>
+		<pmd.plugin.version>3.9.0</pmd.plugin.version>
+		<shade.plugin.version>3.1.0</shade.plugin.version>
 		<surefire.plugin.version>2.19.1</surefire.plugin.version>
 
-		<checkerframework.plugin.version>2.1.10</checkerframework.plugin.version>
+		<checkerframework.plugin.version>2.4.0</checkerframework.plugin.version>
 		<!-- IntelliJ will warn about this line, but the maven-dependency-plugin
 		     does correctly resolve this, so there is nothing to worry about. -->
 		<annotatedJdk>${org.checkerframework:jdk8:jar}</annotatedJdk>

--- a/src/main/java/nl/tudelft/jpacman/board/Board.java
+++ b/src/main/java/nl/tudelft/jpacman/board/Board.java
@@ -21,9 +21,10 @@ public class Board {
      *            The grid of squares with grid[x][y] being the square at column
      *            x, row y.
      */
+    @SuppressWarnings("PMD.ArrayIsStoredDirectly")
     Board(Square[][] grid) {
         assert grid != null;
-        this.board = (Square[][]) grid.clone();
+        this.board = grid;
         assert invariant() : "Initial grid cannot contain null squares";
     }
 

--- a/src/main/java/nl/tudelft/jpacman/board/Board.java
+++ b/src/main/java/nl/tudelft/jpacman/board/Board.java
@@ -23,7 +23,7 @@ public class Board {
      */
     Board(Square[][] grid) {
         assert grid != null;
-        this.board = grid;
+        this.board = (Square[][]) grid.clone();
         assert invariant() : "Initial grid cannot contain null squares";
     }
 

--- a/src/main/java/nl/tudelft/jpacman/board/Unit.java
+++ b/src/main/java/nl/tudelft/jpacman/board/Unit.java
@@ -45,9 +45,9 @@ public abstract class Unit {
 
     /**
      * Returns the square this unit is currently occupying.
+     * Precondition: <code>hasSquare()</code>.
      *
-     * @return The square this unit is currently occupying, or <code>null</code>
-     *         if this unit is not on a square.
+     * @return The square this unit is currently occupying.
      */
     public Square getSquare() {
         assert invariant();

--- a/src/main/java/nl/tudelft/jpacman/npc/ghost/Inky.java
+++ b/src/main/java/nl/tudelft/jpacman/npc/ghost/Inky.java
@@ -92,7 +92,7 @@ public class Inky extends Ghost {
      * destination.
      * </p>
      */
-    // CHECKSTYLE:OFF To keep this more readable.
+    @SuppressWarnings("checkstyle:methodlength")
     @Override
     public @Nullable Direction nextMove() {
         assert hasSquare();
@@ -132,6 +132,4 @@ public class Inky extends Ghost {
         }
         return randomMove();
     }
-    // CHECKSTYLE:ON
-
 }


### PR DESCRIPTION
- Update dependencies to their latest versions
- Adjust checkstyle/pmd configurations conform latest versions
- Deprecate findbugs in favor of spotbugs
- Add jdk8 and jdk9 profies to handle plugins not yet ready for jdk9 (checker framework)
- Enforce maven 3.1.1

Fixes #119.